### PR TITLE
master.py: fix debug_mode initialization

### DIFF
--- a/kAFL-Fuzzer/fuzzer/process/master.py
+++ b/kAFL-Fuzzer/fuzzer/process/master.py
@@ -30,7 +30,7 @@ class MasterProcess:
     def __init__(self, config):
         self.config = config
         self.comm = ServerConnection(self.config)
-        self.debug_mode = config.argument_values['debug'],
+        self.debug_mode = config.argument_values['debug']
 
         self.busy_events = 0
         self.empty_hash = mmh3.hash(("\x00" * self.config.config_values['BITMAP_SHM_SIZE']), signed=False)


### PR DESCRIPTION
Comma in the end makes debug_mode a tuple which is always True after casting to bool:
``` python
>>> debug_mode = False,
>>> bool(debug_mode)
True
```