### PR TITLE
Fix dictionary digesting

### DIFF
--- a/kAFL-Fuzzer/fuzzer/technique/havoc.py
+++ b/kAFL-Fuzzer/fuzzer/technique/havoc.py
@@ -19,7 +19,7 @@ def load_dict(file_name):
     for line in f:
         if not line.startswith("#"):
             try:
-                dict_entries.append((line.split("=\"")[1].split("\"\n")[0]).decode("string_escape"))
+                dict_entries.append((line.split("=\"")[1].split("\"\n")[0]).encode('latin1').decode('unicode-escape').encode('latin1'))
             except:
                 pass
     f.close()


### PR DESCRIPTION
The dictionary option was not working correctly because "string_escape" encoding does not exist in python3.