### PR TITLE
fix logging of rq crash

### DIFF
--- a/kAFL-Fuzzer/common/qemu.py
+++ b/kAFL-Fuzzer/common/qemu.py
@@ -724,7 +724,7 @@ class qemu:
             self.set_payload(payload)
             self.send_payload(timeout_detection=False)
             if self.exit_reason() != "regular":
-                print_warning("RQ execution returned %s", self.exit_reason())
+                print_warning("RQ execution returned %s" % self.exit_reason())
         except Exception as e:
             log_qemu("%s" % traceback.format_exc(), self.qemu_id)
             return False
@@ -736,7 +736,7 @@ class qemu:
             self.send_payload(timeout_detection=False)
             self.soft_reload()
             if self.exit_reason() != "regular":
-                print_warning("RQ execution returned %s", self.exit_reason())
+                print_warning("RQ execution returned %s" % self.exit_reason())
         except Exception as e:
             log_qemu("%s" % traceback.format_exc(), self.qemu_id)
             return False


### PR DESCRIPTION
`print_warning` expects one argument