### PR TITLE
pin west to v0.12

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ endif
 .venv:
 	sudo apt install python3-pip
 	pip install -U pipenv
-	pipenv install west
+	pipenv install
 
 update:
 	west update -k

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,7 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+west = "==0.12"


### PR DESCRIPTION
West 0.13 needs a minor fix in manifest path but this would break
existing installs. Pin 0.12 here and upgrade in a later release..