### PR TITLE
Fix makefile ask become pass

### DIFF
--- a/deploy/Makefile
+++ b/deploy/Makefile
@@ -6,7 +6,7 @@
 # declare all targets in this variable
 ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 ALL_TARGETS:=deploy
-LOCALHOST_INVENTORY:=$(shell grep 'localhost ansible_connection=local' $(ROOT_DIR)/inventory)
+LOCALHOST_INVENTORY:=$(shell grep 'localhost ansible_connection=local' $(ROOT_DIR)/inventory > /dev/null 2>&1; echo $$?)
 ASK_BECOME_PASS:=""
 # declare all target as PHONY
 .PHONY: $(ALL_TARGETS)
@@ -26,7 +26,7 @@ all: deploy
 
 deploy: venv
 	venv/bin/ansible-galaxy install -r requirements.yml --force
-ifeq ($(GREP_FINDINGS),)
+ifeq ($(LOCALHOST_INVENTORY),0)
 	$(eval ASK_BECOME_PASS := -K)
 	@echo "┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓"
 	@echo "┃ Ansible BECOME password: if you are using a passwordless SUDO, skip by pressing enter.┃"

--- a/deploy/Makefile
+++ b/deploy/Makefile
@@ -7,7 +7,6 @@
 ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 ALL_TARGETS:=deploy
 LOCALHOST_INVENTORY:=$(shell grep 'localhost ansible_connection=local' $(ROOT_DIR)/inventory > /dev/null 2>&1; echo $$?)
-ASK_BECOME_PASS:=""
 # declare all target as PHONY
 .PHONY: $(ALL_TARGETS)
 


### PR DESCRIPTION
- use `grep's` return code instead of stdout to test whether inventory's file content is 'localhost ....'
- fix `ASK_BECOME_PASS` default value: when set to an empty string, Makefile's variable substitution would keep the strings

On a side note: Makefiles don't care about undefined variables used in a conditional statement ... (`GREP_FINDINGS`)