### PR TITLE
README: fix CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,10 @@ HW-assisted Feedback Fuzzer for x86 VMs
 </h3>
 
 <p align="center">
-  <a href="https://github.com/Wenzel/kAFL/actions/workflows/CI.yml">
-    <img src="https://github.com/Wenzel/kAFL/actions/workflows/CI.yml/badge.svg" alt="CI">
+  <a href="https://github.com/IntelLabs/kAFL/actions/workflows/CI.yml">
+    <img src="https://github.com/IntelLabs/kAFL/actions/workflows/CI.yml/badge.svg" alt="CI">
   </a>
 </p>
-
 
 kAFL/Nyx is a fast guided fuzzer for the x86 VM. It is great for anything that
 executes as Qemu/KVM guest, in particular x86 firmware, kernels and full-blown


### PR DESCRIPTION
Simply update the CI badge to use Intellabs Actions statuses, now that Github Actions works again:
https://github.com/IntelLabs/kAFL/actions