### PR TITLE
fuzzer: update kvm-intel module loading options for kAFL

### DIFF
--- a/deploy/intellabs/kafl/roles/fuzzer/tasks/post_tasks.yml
+++ b/deploy/intellabs/kafl/roles/fuzzer/tasks/post_tasks.yml
@@ -21,6 +21,13 @@
   tags:
     - kvm_device
 
+- name: Update kvm_intel module loading options
+  copy:
+    dest: /etc/modprobe.d/kafl-kvm-intel.conf
+    content: |
+      options kvm-intel nested=1 ve_injection=1 halt_on_triple_fault=1
+  become: yes
+
 - name: Create .env file
   template:
     src: env.j2


### PR DESCRIPTION
This PR simply creates a dedicated config file `/etc/modprobe.d/kafl-kvm-intel.conf`
with the necessary module options required by kAFL.