### PR TITLE
add optional nyx_packer role

### DIFF
--- a/deploy/intellabs/kafl/roles/nyx_packer/defaults/main.yml
+++ b/deploy/intellabs/kafl/roles/nyx_packer/defaults/main.yml
@@ -1,0 +1,3 @@
+nyx_packer_url: https://github.com/il-steffen/packer
+nyx_packer_revision: kafl_stable
+nyx_packer_root: "{{ kafl_install_root }}/packer"

--- a/deploy/intellabs/kafl/roles/nyx_packer/tasks/main.yml
+++ b/deploy/intellabs/kafl/roles/nyx_packer/tasks/main.yml
@@ -1,0 +1,8 @@
+- name: Clone Nyx Packer
+  git:
+    repo: "{{ nyx_packer_url }}"
+    dest: "{{ nyx_packer_root }}"
+    version: "{{ nyx_packer_revision | default(omit) }}"
+    force: yes
+  tags:
+    - clone


### PR DESCRIPTION
Moving the `nyx_packer` role from ccc repo to kafl.
It is not marked as a dependency of the `fuzzer` role, so it's an optional that will only be installed if explicitely requested, as
~~~yml
    - role: intellabs.kafl.nyx_packer
~~~