### PR TITLE
ansible: fix grub configuration to find correct menuentry

### DIFF
--- a/deploy/intellabs/kafl/roles/kernel/defaults/main.yml
+++ b/deploy/intellabs/kafl/roles/kernel/defaults/main.yml
@@ -1,3 +1,4 @@
+# keep these in sync so we can find the grub entry matching the kernel
+kernel_grep_string: '5.10.73-kafl+'
 kernel_deb_urls:
   - https://github.com/IntelLabs/kafl.linux/releases/download/kvm-nyx-5.10.73/linux-image-5.10.73-kafl+_5.10.73-kafl+-1_amd64.deb
-kernel_grub_default: 'gnulinux-advanced-49764e08-5aba-4fc8-ab39-e9d3b268e429>gnulinux-5.10.73-kafl+-advanced-49764e08-5aba-4fc8-ab39-e9d3b268e429'

--- a/deploy/intellabs/kafl/roles/kernel/tasks/install_kernel.yml
+++ b/deploy/intellabs/kafl/roles/kernel/tasks/install_kernel.yml
@@ -31,13 +31,14 @@
   block:
   - name: Determine Grub menuentry
     shell: |
+      awk -F\' '/submenu.*Advanced\ / {print $4}' /boot/grub/grub.cfg
       awk -F\' '/menuentry.*{{ kernel_grep_string }}/ {print $4}' /boot/grub/grub.cfg |head -1
-    register: grub_menuentry_id
+    register: grub_menuentry_ids
 
   - name: Update /etc/default/grub
     lineinfile:
       regexp: ^GRUB_DEFAULT=
-      line: GRUB_DEFAULT="{{ grub_menuentry_id.stdout }}"
+      line: GRUB_DEFAULT="{{ grub_menuentry_ids.stdout_lines |join('>') }}"
       dest: /etc/default/grub
       backup: yes
     become: yes

--- a/deploy/intellabs/kafl/roles/kernel/tasks/install_kernel.yml
+++ b/deploy/intellabs/kafl/roles/kernel/tasks/install_kernel.yml
@@ -22,26 +22,31 @@
   shell: dpkg -i "{{ down_dir.path }}"/*.deb
   become: yes
 
-- name: Configure boot entry to select new kernel
-  lineinfile:
-    regexp: ^GRUB_DEFAULT=
-    line: GRUB_DEFAULT="{{ kernel_grub_default }}"
-    dest: /etc/default/grub
-    backup: yes
-  become: yes
-  tags:
-    - update_grub
-
-- name: Update GRUB
-  command: update-grub
-  become: yes
-  tags:
-    - update_grub
-
 - name: Remove temporary download directory
   file:
     path: "{{ down_dir.path }}"
     state: absent
+
+- name: Configure boot entry to select new kernel
+  block:
+  - name: Determine Grub menuentry
+    shell: |
+      awk -F\' '/menuentry.*{{ kernel_grep_string }}/ {print $4}' /boot/grub/grub.cfg |head -1
+    register: grub_menuentry_id
+
+  - name: Update /etc/default/grub
+    lineinfile:
+      regexp: ^GRUB_DEFAULT=
+      line: GRUB_DEFAULT="{{ grub_menuentry_id.stdout }}"
+      dest: /etc/default/grub
+      backup: yes
+    become: yes
+
+  - name: Update GRUB
+    command: update-grub
+    become: yes
+  tags:
+    - update_grub
 
 - name: Reboot on new kernel
   reboot:

--- a/deploy/intellabs/kafl/roles/kernel/tasks/main.yml
+++ b/deploy/intellabs/kafl/roles/kernel/tasks/main.yml
@@ -31,5 +31,5 @@
 
 # check if hardware_check in skip-tags -> to force CI run
 - name: Install kernel if needed
-  include_tasks: install_kernel.yml
-  when: "'hardware_check' in ansible_skip_tags or support_test.rc != 0"
+  import_tasks: install_kernel.yml
+  when: "'update_grub' in ansible_run_tags or 'hardware_check' in ansible_skip_tags or support_test.rc != 0"


### PR DESCRIPTION
The menuoption is a system-specific UUID and menutitle is
distro-specific, so this dynamically greps grub.cfg for the
first/best matching entry after kernel install..

Also modify conditional execute to allow "make deploy -- tags update_grub"