### PR TITLE
move targets repo back to targets folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Note: if your nodes require a proxy setup, update the `group_vars/all.yml`.
 
 Now that kAFL has been installed, you can continue by checking one of the example targets available.
 
-This command will clone the [kafl.targets](https://github.com/IntelLabs/kafl.targets) repo into `<install_dir>/examples`
+This command will clone the [kafl.targets](https://github.com/IntelLabs/kafl.targets) repo into `<install_dir>/targets`
 
 ~~~
 make deploy -- --tags targets

--- a/deploy/intellabs/kafl/roles/targets/defaults/main.yml
+++ b/deploy/intellabs/kafl/roles/targets/defaults/main.yml
@@ -1,2 +1,2 @@
 targets_url: https://github.com/IntelLabs/kafl.targets
-targets_dest: "{{ kafl_install_root }}/examples"
+targets_dest: "{{ kafl_install_root }}/targets"


### PR DESCRIPTION
Not important enough to rename the repo, and its confusing to download
'targets' and then have an examples/ folder...