### PR TITLE
make remote installation configurable

### DIFF
--- a/deploy/group_vars/all.yml
+++ b/deploy/group_vars/all.yml
@@ -2,3 +2,5 @@ proxy_env:
   # set your proxy here.
   # http_proxy:
   # https_proxy:
+install:
+  # workspace_root: "{{ ansible_env.HOME }}/workspace"

--- a/deploy/intellabs/kafl/roles/fuzzer/defaults/main.yml
+++ b/deploy/intellabs/kafl/roles/fuzzer/defaults/main.yml
@@ -1,5 +1,5 @@
 # define shared variables here, since kafl is the top-level role
-kafl_install_root: "{{ playbook_dir | dirname if ansible_connection == 'local' else ansible_env.HOME }}/kafl"
+kafl_install_root: "{{ workspace_root }}/kafl"
 
 libxdc_root: "{{ kafl_install_root }}/libxdc"
 capstone_root: "{{ kafl_install_root }}/capstone"

--- a/deploy/site.yml
+++ b/deploy/site.yml
@@ -3,7 +3,8 @@
     http_proxy: "{{ proxy_env.http_proxy | default(lookup('env', 'HTTP_PROXY')) }}"
     https_proxy: "{{ proxy_env.https_proxy | default(lookup('env', 'HTTPS_PROXY')) }}"
   vars:
-    workspace_root: "{{ playbook_dir | dirname if ansible_connection == 'local' else ansible_env.HOME + '/kafl'}}"
+    workspace_default: "{{ playbook_dir | dirname if ansible_connection == 'local' else ansible_env.HOME + 'workspace' }}"
+    workspace_root: "{{ install.workspace_root | default(workspace_default) }}"
 
   pre_tasks:
     - name: apt update to ensure root access is available (or fail early)


### PR DESCRIPTION
- expose remote installation target as workspace_root variable
- change default install to use ~/workspace/kafl/ with env.sh at toplevel