### PR TITLE
deploy: use host_vars to force local ansible_connection for localhost

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -86,20 +86,26 @@ jobs:
           echo '{"git_clone_depth": 1}' >> parameters.json
         working-directory: deploy
 
-      # the service container runs is accessible on 127.0.0.1:5000
-      - name: Setup inventory
-        run: >
-          echo 'localhost
-          ansible_port=5000
-          ansible_user=root
-          ansible_ssh_pass=toor
-          ansible_ssh_common_args="-o StrictHostKeyChecking=no"'
-          > inventory
-        working-directory: deploy
-
       - name: Setup ansible
         run: |
           make venv
+        working-directory: deploy
+
+      # the service container runs is accessible on 127.0.0.1:5000
+      - name: Setup inventory
+        run: |
+          venv/bin/python - << '__HERE__'
+          import yaml
+
+          with open("host_vars/localhost.yml", "w") as f:
+            data = {
+              "ansible_port": 5000,
+              "ansible_user": "root",
+              "ansible_ssh_pass": "toor",
+              "ansible_ssh_common_args": "-o StrictHostKeyChecking=no"
+            }
+            yaml.dump(data, f)
+          __HERE__
         working-directory: deploy
 
       - name: Install Python3 on service container

--- a/README.md
+++ b/README.md
@@ -77,9 +77,9 @@ If you are using a _passwordless sudo_ setup, just skip this by pressing enter.
 kAFL's deployment offers the possibility of remote installation using Ansible.
 Update the `deploy/inventory` file according to the [Ansible inventory
 guide](https://docs.ansible.com/ansible/latest/user_guide/intro_inventory.html)
-and make sure to **remove** the first line:
+and make sure to **remove** the `localhost` host:
 
-> localhost ansible_connection=local
+> localhost
 
 
 Deployment will install kAFL to `$HOME/kafl` of the target machines:

--- a/deploy/Makefile
+++ b/deploy/Makefile
@@ -6,7 +6,7 @@
 # declare all targets in this variable
 ALL_TARGETS:=deploy clean update build
 ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
-LOCALHOST_INVENTORY:=$(shell grep 'localhost ansible_connection=local' $(ROOT_DIR)/inventory > /dev/null 2>&1; echo $$?)
+LOCALHOST_INVENTORY:=$(shell grep 'localhost' $(ROOT_DIR)/inventory > /dev/null 2>&1; echo $$?)
 ANSIBLE_COMMAND:=venv/bin/ansible-playbook -i $(ROOT_DIR)/inventory $(ROOT_DIR)/site.yml
 # declare all target as PHONY
 .PHONY: $(ALL_TARGETS)

--- a/deploy/host_vars/localhost.yml
+++ b/deploy/host_vars/localhost.yml
@@ -1,0 +1,2 @@
+# force default local connection plugin for localhost instead of ssh
+ansible_connection: local

--- a/deploy/inventory
+++ b/deploy/inventory
@@ -1,1 +1,1 @@
-localhost ansible_connection=local
+localhost


### PR DESCRIPTION
Use Ansible's [host_vars](https://docs.ansible.com/ansible/latest/user_guide/intro_inventory.html#assigning-a-variable-to-one-machine-host-variables) to force `ansible_connection` to `local`.

Previous behavior was to force this in the `inventory`, but it had the be maintained in the makefile as well and not documented.

Now the inventory only contains `localhost`, which is more simple and explicit.