### PR TITLE
Deploy/check mode compatible

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -38,6 +38,18 @@ jobs:
         run: |
           ./venv/bin/ansible-lint -x 'meta-no-info'
 
+  check-mode:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.8'
+
+      - name: Run deployment in check mode (dry-run)
+        run: make deploy -- --check
+
   local:
     strategy:
         matrix:

--- a/deploy/intellabs/kafl/roles/fuzzer/tasks/main.yml
+++ b/deploy/intellabs/kafl/roles/fuzzer/tasks/main.yml
@@ -12,6 +12,7 @@
     path: "{{ kafl_install_root | dirname }}"
     state: directory
     mode: 0775
+  when: not ansible_check_mode
 
 - name: Install kAFL system dependencies
   ansible.builtin.package:
@@ -38,6 +39,7 @@
   args:
     chdir: "{{ kafl_install_root }}"
   changed_when: true
+  when: not ansible_check_mode
 
 - name: Install kAFL fuzzer
   ansible.builtin.command: |
@@ -45,6 +47,7 @@
   args:
     chdir: "{{ kafl_install_root }}"
   changed_when: true
+  when: not ansible_check_mode
   tags:
     - build
 

--- a/deploy/intellabs/kafl/roles/fuzzer/tasks/post_tasks.yml
+++ b/deploy/intellabs/kafl/roles/fuzzer/tasks/post_tasks.yml
@@ -20,3 +20,4 @@
   become: true
   tags:
     - kvm_device
+  when: not ansible_check_mode

--- a/deploy/intellabs/kafl/roles/ghidra/tasks/main.yml
+++ b/deploy/intellabs/kafl/roles/ghidra/tasks/main.yml
@@ -18,6 +18,7 @@
         url: "{{ ghidra_url }}"
         dest: "{{ kafl_install_root }}/ghidra.zip"
         checksum: "sha256:9c73b6657413686c0af85909c20581e764107add2a789038ebc6eca49dc4e812"
+        mode: 0644
 
     - name: Extract Ghidra
       ansible.builtin.unarchive:
@@ -29,4 +30,4 @@
       ansible.builtin.file:
         path: "{{ kafl_install_root }}/ghidra.zip"
         state: absent
-  when: not stat_ghidra_bin.stat.exists
+  when: not stat_ghidra_bin.stat.exists and not ansible_check_mode

--- a/deploy/intellabs/kafl/roles/kernel/tasks/install_kernel.yml
+++ b/deploy/intellabs/kafl/roles/kernel/tasks/install_kernel.yml
@@ -9,6 +9,7 @@
   ansible.builtin.tempfile:
     state: directory
   register: down_dir
+  check_mode: false
 
 - name: Download deb packages
   ansible.builtin.get_url:
@@ -29,6 +30,7 @@
   ansible.builtin.file:
     path: "{{ down_dir.path }}"
     state: absent
+  check_mode: false
 
 - name: Configure boot entry to select new kernel
   block:
@@ -38,6 +40,7 @@
         awk -F\' '/menuentry.*{{ kernel_grep_string }}/ {print $4}' /boot/grub/grub.cfg |head -1
       register: grub_menuentry_ids
       when: true
+      check_mode: false
 
     - name: Update /etc/default/grub
       ansible.builtin.lineinfile:

--- a/deploy/intellabs/kafl/roles/kernel/tasks/main.yml
+++ b/deploy/intellabs/kafl/roles/kernel/tasks/main.yml
@@ -11,18 +11,21 @@
   ansible.builtin.tempfile:
     state: directory
   register: temp_compile
+  check_mode: false
 
 - name: Upload support_test.c
   ansible.builtin.copy:
     src: files/support_test.c
     dest: "{{ temp_compile.path }}/support_test.c"
     mode: 0644
+  check_mode: false
 
 - name: Compile support_test.c
   ansible.builtin.command: |
     gcc "{{ temp_compile.path }}/support_test.c" -o "{{ temp_compile.path }}/support_test"
   register: compile_result
   changed_when: false
+  check_mode: false
 
 - name: Run support_test
   ansible.builtin.command: |
@@ -30,6 +33,7 @@
   ignore_errors: true
   register: support_test
   changed_when: false
+  check_mode: false
   tags:
     - hardware_check
 
@@ -37,6 +41,7 @@
   ansible.builtin.file:
     path: "{{ temp_compile.path }}"
     state: absent
+  check_mode: false
 
 # check if hardware_check in skip-tags -> to force CI run
 - name: Install kernel if needed

--- a/deploy/intellabs/kafl/roles/qemu/tasks/main.yml
+++ b/deploy/intellabs/kafl/roles/qemu/tasks/main.yml
@@ -37,6 +37,6 @@
   environment:
     CAPSTONE_ROOT: "{{ capstone_root }}"
     LIBXDC_ROOT: "{{ libxdc_root }}"
-  when: true
+  when: not ansible_check_mode
   tags:
     - build


### PR DESCRIPTION
Keep the playbook compatibility with Ansible [check mode](https://docs.ansible.com/ansible/latest/user_guide/playbooks_checkmode.html) (or dry-run).

This is useful in the tutorial for users who want to have a glimpse of what the playbook would change on the system.