### PR TITLE
deploy: dockerize kAFL fuzzer

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.gitignore
+.git/
+.github/
+Dockerfile
+README.md
+env.sh
+docs/
+kafl/
+deploy/venv/

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -167,7 +167,7 @@ jobs:
       - name: Run PT tests
         run: cargo test
 
-  Dockerfile-lint:
+  hadolint-lint:
       runs-on: ubuntu-latest
       steps:
         - uses: actions/checkout@v3
@@ -184,10 +184,8 @@ jobs:
           uses: actions/upload-artifact@v3
           with:
             name: hadolint
-
             path: ${{ github.workspace }}/hadolint.out
           if: ${{ failure() }}
-
 
   build_image:
     runs-on: ubuntu-latest
@@ -207,6 +205,35 @@ jobs:
           push: false
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+  snyk-lint:
+    needs: [build_image]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Run Snyk to check Docker image for vulnerabilities
+      uses: snyk/actions/docker@master
+      env:
+        SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+      with:
+        image: intellabs/kafl
+        args: --file=Dockerfile
+
+    - name: Upload results
+      uses: actions/upload-artifact@v3
+      with:
+        name: snyk-docker
+        path: |
+          snyk.json
+          snyk.sarif
+      if: ${{ failure() }}
+
+    - name: Upload result to GitHub Code Scanning
+      uses: github/codeql-action/upload-sarif@v2
+      with:
+        sarif_file: snyk.sarif
+      if: ${{ failure() }}
 
   release:
     # this job makes an official Github release

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -167,6 +167,28 @@ jobs:
       - name: Run PT tests
         run: cargo test
 
+  Dockerfile-lint:
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@v3
+
+        - name: Lint Dockerfile
+          id: hadolint
+          uses: hadolint/hadolint-action@v3.0.0
+          with:
+            # only consider errors, not warning or info level
+            failure-threshold: error
+            output-file: ${{ github.workspace }}/hadolint.out
+
+        - name: Upload hadolint output artifact
+          uses: actions/upload-artifact@v3
+          with:
+            name: hadolint
+
+            path: ${{ github.workspace }}/hadolint.out
+          if: ${{ failure() }}
+
+
   build_image:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -167,6 +167,25 @@ jobs:
       - name: Run PT tests
         run: cargo test
 
+  build_image:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4.1.1
+        with:
+          images: intellabs/kafl
+
+      - name: Build image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: false
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
   release:
     # this job makes an official Github release
     needs: [ansible-lint, check-mode, local, remote, nyx-testing]

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -206,7 +206,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
-  snyk-lint:
+  snyk-lint-dockerfile:
     needs: [build_image]
     runs-on: ubuntu-latest
     steps:
@@ -234,6 +234,32 @@ jobs:
       with:
         sarif_file: snyk.sarif
       if: ${{ failure() }}
+
+  snyk-lint-python:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.8'
+
+      - name: install dependencies
+        run: pip install -r requirements.txt
+        working-directory: deploy
+
+      - name: Run Snyk to check for vulnerabilities
+        uses: snyk/actions/python@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          args: --sarif-file-output=snyk.sarif
+
+      - name: Upload result to GitHub Code Scanning
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: snyk.sarif
+        if: ${{ failure() }}
 
   release:
     # this job makes an official Github release

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -240,6 +240,13 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - uses: snyk/actions/setup@master
+
+      - name: snyk auth
+        run: snyk auth
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+
       - uses: actions/setup-python@v2
         with:
           python-version: '3.8'

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN ./kafl/.venv/bin/pip install pyinstaller==${pyinstaller_version} && \
 RUN printf "%s\n" 'qemu_path: /usr/local/bin/qemu-system-x86_64' \
                   'ptdump_path: /usr/local/bin/ptdump' \
                   'radamsa_path: /usr/local/bin/radamsa' \
-                  'workdir: /workdir' >> settings.yaml
+                  'workdir: /mnt/workdir' >> settings.yaml
 
 FROM ${baseimage} as run
 # install QEMU
@@ -54,8 +54,9 @@ COPY --from=build /app/settings.yaml /etc/xdg/kAFL/
 # install shared libraries for QEMU
 RUN apt-get update && apt-get install -y --no-install-recommends libpixman-1-0 libpng16-16 libglib2.0-0 && apt-get clean
 
-# define kAFL WORKDIR volume (not to be confused with Dockerfile's WORKDIR)
-VOLUME ["/workdir"]
+WORKDIR /mnt/workdir
+# define kAFL WORKDIR as volume
+VOLUME ["/mnt/workdir"]
 
 # Setup env to run Dockerized Python app
 ENV LANG C.UF-8

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,10 @@ COPY --from=build /app/kafl/fuzzer/dist/kafl /usr/local/bin
 # install config file
 COPY --from=build /app/settings.yaml /etc/xdg/kAFL/
 
+# TODO: switch to full static QEMU build
+# install shared libraries for QEMU
+RUN apt-get update && apt-get install -y --no-install-recommends libpixman-1-0 libpng16-16 libglib2.0-0 && apt-get clean
+
 # define kAFL WORKDIR volume (not to be confused with Dockerfile's WORKDIR)
 VOLUME ["/workdir"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,8 @@ RUN ./kafl/.venv/bin/pip install pyinstaller==${pyinstaller_version} && \
 # create kafl config file
 RUN echo "qemu_path: /usr/local/bin/qemu-system-x86_64" >> settings.yaml && \
     echo "ptdump_path: /usr/local/bin/ptdump" >> settings.yaml && \
-    echo "radamsa_path: /usr/local/bin/radamsa" >> settings.yaml
+    echo "radamsa_path: /usr/local/bin/radamsa" >> settings.yaml && \
+    echo "workdir: /workdir" >> settings.yaml
 
 FROM ${baseimage} as run
 # install QEMU
@@ -45,6 +46,9 @@ COPY --from=build /app/kafl/libxdc/build/ptdump /usr/local/bin
 COPY --from=build /app/kafl/fuzzer/dist/kafl /usr/local/bin
 # install config file
 COPY --from=build /app/settings.yaml /etc/xdg/kAFL/
+
+# define kAFL WORKDIR volume (not to be confused with Dockerfile's WORKDIR)
+VOLUME ["/workdir"]
 
 # Setup env to run Dockerized Python app
 ENV LANG C.UF-8

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright (C) Intel Corporation, 2022
 # SPDX-License-Identifier: MIT
-ARG baseimage=debian:bullseye-slim
+ARG baseimage=debian:bullseye-slim$
 FROM ${baseimage} as build
 ARG pyinstaller_version=5.7.0
 
@@ -9,7 +9,7 @@ COPY . .
 
 # skip ghidra since it adds 1G to the final image,
 # and we don't use it for our fuzzing use case with Docker
-RUN apt-get update && apt-get install -y build-essential git python3 python3-venv && \
+RUN apt-get update && apt-get install -y --no-install-recommends build-essential git python3 python3-venv && \
     make deploy -- --tags fuzzer --skip-tags kernel,kvm_device,ghidra
 
 # create pyinstaller stub for executable Python packages

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,59 @@
+# Copyright (C) Intel Corporation, 2022
+# SPDX-License-Identifier: MIT
+ARG baseimage=debian:bullseye-slim
+FROM ${baseimage} as build
+ARG pyinstaller_version=5.7.0
+
+WORKDIR /app
+COPY . .
+
+# skip ghidra since it adds 1G to the final image,
+# and we don't use it for our fuzzing use case with Docker
+RUN apt-get update && apt-get install -y build-essential git python3 python3-venv && \
+    make deploy -- --tags fuzzer --skip-tags kernel,kvm_device,ghidra
+
+# create pyinstaller stub for executable Python packages
+# https://github.com/pyinstaller/pyinstaller/issues/2560
+RUN echo "from kafl_fuzzer.__main__ import main\nmain()" > ./kafl/fuzzer/stub.py
+# TODO: how to make pyinstaller detect Extension modules ?
+# move build/*/bitmap*.so as bitmap.so
+# include it in the pyinstaller executable
+RUN cd ./kafl/fuzzer && find build -name 'bitmap*.so' -exec mv {} bitmap.so \;
+# compile kafl as standalone python app
+RUN ./kafl/.venv/bin/pip install pyinstaller==${pyinstaller_version} && \
+    cd ./kafl/fuzzer  && /app/kafl/.venv/bin/pyinstaller \
+        --onefile --name kafl \
+        --add-data kafl_fuzzer/common/config/default_settings.yaml:kafl_fuzzer/common/config \
+        --add-data kafl_fuzzer/logging.yaml:kafl_fuzzer \
+        --add-binary bitmap.so:kafl_fuzzer/native \
+        stub.py
+
+# create kafl config file
+RUN echo "qemu_path: /usr/local/bin/qemu-system-x86_64" >> settings.yaml && \
+    echo "ptdump_path: /usr/local/bin/ptdump" >> settings.yaml && \
+    echo "radamsa_path: /usr/local/bin/radamsa" >> settings.yaml
+
+FROM ${baseimage} as run
+# install QEMU
+COPY --from=build /app/kafl/qemu/x86_64-softmmu/qemu-system-x86_64 /usr/local/bin/
+COPY --from=build /app/kafl/qemu/pc-bios/* /usr/local/share/qemu-firmware/
+# install radamsa
+COPY --from=build /app/kafl/radamsa/bin/radamsa /usr/local/bin
+# install ptdump
+COPY --from=build /app/kafl/libxdc/build/ptdump /usr/local/bin
+# installer fuzzer
+COPY --from=build /app/kafl/fuzzer/dist/kafl /usr/local/bin
+# install config file
+COPY --from=build /app/settings.yaml /etc/xdg/kAFL/
+
+# Setup env to run Dockerized Python app
+ENV LANG C.UF-8
+ENV LC_ALL C.UTF-8
+# don't write .pyc compiled code
+ENV PYTHONDONTWRITEBYTECODE 1
+# enable python stacktraces on segfaults
+ENV PYTHONFAULTHANDLER 1
+# ensure that python output is sent straight to container logs without buffering
+ENV PYTHONUNBUFFERED 1
+
+ENTRYPOINT ["kafl"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright (C) Intel Corporation, 2022
 # SPDX-License-Identifier: MIT
-ARG baseimage=debian:bullseye-slim
+ARG baseimage=python:3.11-slim
 FROM ${baseimage} as build
 ARG pyinstaller_version=5.7.0
 
@@ -9,7 +9,7 @@ COPY . .
 
 # skip ghidra since it adds 1G to the final image,
 # and we don't use it for our fuzzing use case with Docker
-RUN apt-get update && apt-get install -y --no-install-recommends build-essential git python3 python3-venv && \
+RUN apt-get update && apt-get install -y --no-install-recommends build-essential git libffi-dev && \
     make deploy -- --tags fuzzer --skip-tags kernel,kvm_device,ghidra
 
 # create pyinstaller stub for executable Python packages


### PR DESCRIPTION
This PR Dockerize the kAFL fuzzer.
It's based on https://github.com/Wenzel/kAFL/tree/docker_workspace, updated with the new Ansible deployment.

To build the image:
```shell
docker build -t kafl .
```

To test the image on [`examples/linux-kernel`](https://github.com/IntelLabs/kafl.targets/tree/master/linux-kernel)
*Make sure to create the workdir beforehand*, otherwise the Docker daemon will create it as `root:root` and `kafl` will fail.
```shell
docker run \
        -ti --rm \
        --device /dev/kvm \
        -v $(pwd)/kafl_config.yaml:/mnt/kafl_config.yaml \
        -v /dev/shm/kafl:/mnt/workdir \
        -v $(pwd)/linux-guest/arch/x86/boot/bzImage:/mnt/kernel \
        -e KAFL_CONFIG_FILE=/mnt/kafl_config.yaml \
        --user $(id -u):$(id -g) \
        --group-add $(getent group kvm | cut -d: -f3) \
        kafl \
        --purge \
        -w /mnt/workdir \
        --redqueen --grimoire -D --radamsa \
        --kernel /mnt/kernel \
        -t 0.1 -ts 0.01 -m 512 --log-crashes -p 2
````

# TODO

- [x] run as user
- [x] why do we need graphviz though ?
- [x] copying the venv is a flaky solution
- [x] this assumes non-editable kafl_fuzzer install in the deployment. introduce a variable to customize that behavior
- [ ] QEMU SHM/socket error:
![image](https://user-images.githubusercontent.com/964610/206232688-97a24f59-11ea-456c-82b4-266006fc2cda.png)
- [ ] synchronization_lock_crash_found

