### PR TITLE
KAFL_CONFIG_FILE: adopt new default path

### DIFF
--- a/deploy/intellabs/kafl/roles/fuzzer/templates/env.j2
+++ b/deploy/intellabs/kafl/roles/fuzzer/templates/env.j2
@@ -12,8 +12,10 @@ export EXAMPLES_ROOT="{{ examples_root }}"
 
 # workspace defaults
 export KAFL_WORKSPACE="{{ workspace_root }}"
-export KAFL_CONFIG_FILE="{{ fuzzer_root }}/kafl.yaml"
 export KAFL_WORKDIR="/dev/shm/kafl_{{ ansible_user_id }}"
+
+# kAFL configuration (default: point to package defaults)
+export KAFL_CONFIG_FILE="{{ fuzzer_root }}/kafl_fuzzer/config_default.yaml"
 
 # activate python venv
 source $KAFL_ROOT/.venv/bin/activate


### PR DESCRIPTION
KAFL_CONFIG_FILE is now optional and can be used to override the package defaults at kafl_fuzzer/config_default.yaml.

For usability, keep the variable in env.sh and set it to this new package default.