### PR TITLE
fuzzer: set nyx_packer as optional dependency

### DIFF
--- a/deploy/intellabs/kafl/roles/fuzzer/meta/main.yml
+++ b/deploy/intellabs/kafl/roles/fuzzer/meta/main.yml
@@ -14,3 +14,7 @@ dependencies:
   - role: examples
     tags:
       - examples
+  - role: nyx_packer
+    tags:
+      - nyx_packer
+    when: install_nyx_packer

--- a/deploy/intellabs/kafl/roles/fuzzer/tasks/main.yml
+++ b/deploy/intellabs/kafl/roles/fuzzer/tasks/main.yml
@@ -51,11 +51,5 @@
   tags:
     - build
 
-- name: Install nyx_packer
-  ansible.builtin.include_role:
-    name: nyx_packer
-    public: true
-  when: install_nyx_packer
-
 - name: Import post_tasks
   import_tasks: post_tasks.yml


### PR DESCRIPTION
This PR improves #113 by removing the `include_role` hack, and using a conditional role dependency based on `install_nyx_packer` boolean variable value