### PR TITLE
fuzzer: use official ansible pip module

### DIFF
--- a/deploy/intellabs/kafl/roles/fuzzer/defaults/main.yml
+++ b/deploy/intellabs/kafl/roles/fuzzer/defaults/main.yml
@@ -10,3 +10,4 @@ capstone_root: "{{ kafl_install_root }}/capstone"
 
 fuzzer_url: 'https://github.com/IntelLabs/kafl.fuzzer'
 fuzzer_root: "{{ kafl_install_root }}/fuzzer"
+fuzzer_venv_root: "{{ kafl_install_root }}/.venv"

--- a/deploy/intellabs/kafl/roles/fuzzer/tasks/main.yml
+++ b/deploy/intellabs/kafl/roles/fuzzer/tasks/main.yml
@@ -22,6 +22,7 @@
     - libgraphviz-dev
     - python3-dev
     - python3-venv
+    - python3-setuptools
 
 - name: Clone repo
   ansible.builtin.git:
@@ -33,19 +34,12 @@
   tags:
     - clone
 
-- name: Create venv
-  ansible.builtin.command: |
-    python3 -m venv .venv
-  args:
-    chdir: "{{ kafl_install_root }}"
-  changed_when: true
-  when: not ansible_check_mode
-
 - name: Install kAFL fuzzer
-  ansible.builtin.command: |
-    .venv/bin/python -m pip install -e "file://{{ fuzzer_root }}"
-  args:
-    chdir: "{{ kafl_install_root }}"
+  ansible.builtin.pip:
+    name: "file://{{ fuzzer_root }}"
+    editable: true
+    virtualenv: "{{ fuzzer_venv_root }}"
+    virtualenv_command: "python3 -m venv"
   changed_when: true
   when: not ansible_check_mode
   tags:


### PR DESCRIPTION
This PR uses the official [`ansible.builtin.pip`](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/pip_module.html) module to install the fuzzer, instead of custom commands.

Also it defines and exports a new variable: `fuzzer_venv_root`, which will be useful for he future `bkc` role @il-steffen 