### PR TITLE
Switch to building qemu 'static' by default

### DIFF
--- a/deploy/intellabs/kafl/roles/qemu/tasks/main.yml
+++ b/deploy/intellabs/kafl/roles/qemu/tasks/main.yml
@@ -31,7 +31,7 @@
     - clone
 
 - name: Build QEMU
-  ansible.builtin.command: ./compile_qemu_nyx.sh lto
+  ansible.builtin.command: ./compile_qemu_nyx.sh static
   args:
     chdir: "{{ qemu_root }}"
   environment:


### PR DESCRIPTION
Switch from lto to static. LTO is quite slow and does not parallelize well:
$ time ./compile_qemu_nyx.sh lto     # real    3m43.203s
$ time ./compile_qemu_nyx.sh static # real    0m52.631s

This is easy for users to customize:
$ make env
$ cd $QEMU_ROOT
$ ./compile_qemu_nyx.sh debug