### PR TITLE
.github: adopt new RELEASE changelog style

### DIFF
--- a/.github/RELEASE.md
+++ b/.github/RELEASE.md
@@ -4,7 +4,7 @@
 
 # ✨ Improvements
 
-/
+- Follow [kafl_fuzzer](https://github.com/IntelLabs/kafl.fuzzer) changelog style (https://github.com/IntelLabs/kAFL/pull/123)
 
 # 🔧 Fixes
 

--- a/.github/RELEASE.md
+++ b/.github/RELEASE.md
@@ -1,0 +1,19 @@
+# 🌟 Features
+
+/
+
+# ✨ Improvements
+
+/
+
+# 🔧 Fixes
+
+/
+
+# 📖 Documentation
+
+/
+
+# 🧰 Behind the scenes
+
+/

--- a/.github/RELEASE.txt
+++ b/.github/RELEASE.txt
@@ -1,5 +1,0 @@
-# User changes
-
-- `env.sh`: has been moved into `kafl` install directory.
-    - `WORKSPACE` becomes prefixed -> `KAFL_WORKSPACE`
-    - `intellabs.kafl.fuzzer` is now responsible for creating `env.sh`

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -188,7 +188,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ steps.get_version.outputs.version }}
-          body_path: ${{ github.workspace }}/.github/RELEASE.txt
+          body_path: ${{ github.workspace }}/.github/RELEASE.md
         if: startsWith(github.ref, 'refs/tags/v')
 
       - id: step_upload_url


### PR DESCRIPTION
Follow kafl_fuzzer's [RELEASE.md](https://github.com/IntelLabs/kafl.fuzzer/commit/6cf99e51294ff5c8db773a7673a2870929262116?short_path=4faaf54#diff-4faaf5456b1682f37cdfd0acf72d3e030f0c757a6e1d429614920d6a16fa300f) style

