### PR TITLE
ci: fetch whole history in docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,6 +11,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          # fetch the whole history to get tags
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v2


### PR DESCRIPTION
This is required so that `git describe --abbrev=0` can fetch the latest tag:
![image](https://user-images.githubusercontent.com/964610/202190186-07804575-8725-4e24-88bd-cdc2f5dbc832.png)
