### PR TITLE
Fix docs GitHub pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,6 +21,11 @@ jobs:
         run: make html
         working-directory: docs
 
+      # allow to serve dirs starting with _ (_static for example)
+      - name: Add .nojekyll
+        run: touch .nojekyll
+        working-directory: docs/build/html
+
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@releases/v4
         with:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -40,7 +40,6 @@ exclude_patterns = []
 
 html_title = project
 html_theme = 'furo'
-html_static_path = ['_static']
 html_theme_options = {
     # TODO: edit when PR on upstream repo
     "source_repository": "https://github.com/IntelLabs/kAFL",


### PR DESCRIPTION
Following:
https://github.blog/2009-12-29-bypassing-jekyll-on-github-pages/