### PR TITLE
Dockerize kAFL

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,9 +1,11 @@
-.gitignore
-.git/
-.github/
-Dockerfile
-README.md
-env.sh
-docs/
-kafl/
-deploy/venv/
+# ignore everything
+*
+
+# allow deploy
+!deploy/
+
+# allow Makefile
+!Makefile
+
+# ignore nested venvs
+**/venv

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.gitignore
+.git/
+.github/
+Dockerfile
+README.md
+env.sh
+docs/
+kafl/
+deploy/venv/

--- a/.github/DOCKER.md
+++ b/.github/DOCKER.md
@@ -1,0 +1,3 @@
+# intellabs/kafl
+
+> Docker image to execute kAFL fuzzer

--- a/.github/RELEASE.md
+++ b/.github/RELEASE.md
@@ -1,6 +1,7 @@
 # 🌟 Features
 
 - Add Sphinx-based documentation system hosted at [https://IntelLabs.github.io/kAFL/](https://IntelLabs.github.io/kAFL/) (https://github.com/IntelLabs/kAFL/pull/122)
+- Add Dockerfile to build kAFL as Docker image (#136)
 
 # ✨ Improvements
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -205,35 +205,21 @@ jobs:
           push: false
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+    
+      # TODO: refactor in a separate in security.yml workflow
+      - name: Run Snyk to check Docker image for vulnerabilities
+        uses: snyk/actions/docker@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          image: ${{ steps.meta.outputs.tags }}
+          args: --file=Dockerfile
+        continue-on-error: true
 
-  snyk-lint-dockerfile:
-    needs: [build_image]
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-
-    - name: Run Snyk to check Docker image for vulnerabilities
-      uses: snyk/actions/docker@master
-      env:
-        SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-      with:
-        image: intellabs/kafl
-        args: --file=Dockerfile
-
-    - name: Upload results
-      uses: actions/upload-artifact@v3
-      with:
-        name: snyk-docker
-        path: |
-          snyk.json
-          snyk.sarif
-      if: ${{ failure() }}
-
-    - name: Upload result to GitHub Code Scanning
-      uses: github/codeql-action/upload-sarif@v2
-      with:
-        sarif_file: snyk.sarif
-      if: ${{ failure() }}
+      - name: Upload result to GitHub Code Scanning
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: snyk.sarif
 
   release:
     # this job makes an official Github release

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -167,26 +167,6 @@ jobs:
       - name: Run PT tests
         run: cargo test
 
-  hadolint-lint:
-      runs-on: ubuntu-latest
-      steps:
-        - uses: actions/checkout@v3
-
-        - name: Lint Dockerfile
-          id: hadolint
-          uses: hadolint/hadolint-action@v3.0.0
-          with:
-            # only consider errors, not warning or info level
-            failure-threshold: error
-            output-file: ${{ github.workspace }}/hadolint.out
-
-        - name: Upload hadolint output artifact
-          uses: actions/upload-artifact@v3
-          with:
-            name: hadolint
-            path: ${{ github.workspace }}/hadolint.out
-          if: ${{ failure() }}
-
   docker-image:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -187,7 +187,7 @@ jobs:
             path: ${{ github.workspace }}/hadolint.out
           if: ${{ failure() }}
 
-  build_image:
+  docker-image:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -229,7 +229,7 @@ jobs:
 
   release:
     # this job makes an official Github release
-    needs: [ansible-lint, check-mode, local, remote, nyx-testing]
+    needs: [ansible-lint, check-mode, local, remote, docker-image, nyx-testing]
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.get_version.outputs.version }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -167,7 +167,7 @@ jobs:
       - name: Run PT tests
         run: cargo test
 
-  Dockerfile-lint:
+  hadolint-lint:
       runs-on: ubuntu-latest
       steps:
         - uses: actions/checkout@v3
@@ -184,10 +184,8 @@ jobs:
           uses: actions/upload-artifact@v3
           with:
             name: hadolint
-
             path: ${{ github.workspace }}/hadolint.out
           if: ${{ failure() }}
-
 
   build_image:
     runs-on: ubuntu-latest
@@ -207,6 +205,35 @@ jobs:
           push: false
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+  snyk-lint:
+    needs: [build_image]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Run Snyk to check Docker image for vulnerabilities
+      uses: snyk/actions/docker@master
+      env:
+        SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+      with:
+        image: intellabs/kafl
+        args: --file=Dockerfile
+
+    - name: Upload results
+      uses: actions/upload-artifact@v3
+      with:
+        name: snyk-docker
+        path: |
+          snyk.json
+          snyk.sarif
+      if: ${{ failure() }}
+
+    - name: Upload result to GitHub Code Scanning
+      uses: github/codeql-action/upload-sarif@v2
+      with:
+        sarif_file: snyk.sarif
+      if: ${{ failure() }}
 
   release:
     # this job makes an official Github release

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -235,35 +235,6 @@ jobs:
         sarif_file: snyk.sarif
       if: ${{ failure() }}
 
-  snyk-lint-python:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-
-      - uses: actions/setup-python@v2
-        with:
-          python-version: '3.8'
-
-      - name: install dependencies
-        run: pip install -r requirements.txt
-        working-directory: deploy
-
-      - name: Copy requirements.txt at root of GITHUB_WORKSPACE for Snyk
-        run: cp deploy/requirements.txt .
-
-      - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/python@master
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-        with:
-          args: --sarif-file-output=snyk.sarif
-
-      - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
-        with:
-          sarif_file: snyk.sarif
-        if: ${{ failure() }}
-
   release:
     # this job makes an official Github release
     needs: [ansible-lint, check-mode, local, remote, nyx-testing]

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -167,6 +167,28 @@ jobs:
       - name: Run PT tests
         run: cargo test
 
+  Dockerfile-lint:
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@v3
+
+        - name: Lint Dockerfile
+          id: hadolint
+          uses: hadolint/hadolint-action@v3.0.0
+          with:
+            # only consider errors, not warning or info level
+            failure-threshold: error
+            output-file: ${{ github.workspace }}/hadolint.out
+
+        - name: Upload hadolint output artifact
+          uses: actions/upload-artifact@v3
+          with:
+            name: hadolint
+
+            path: ${{ github.workspace }}/hadolint.out
+          if: ${{ failure() }}
+
+
   build_image:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -171,6 +171,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          path: kafl
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2.2.1
@@ -184,7 +186,7 @@ jobs:
       - name: Build image
         uses: docker/build-push-action@v3
         with:
-          context: .
+          context: kafl/
           push: false
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -207,6 +209,42 @@ jobs:
       #   uses: github/codeql-action/upload-sarif@v2
       #   with:
       #     sarif_file: snyk.sarif
+
+      - run: mkdir bench-logs
+
+      - uses: actions/checkout@v3
+        with:
+          repository: docker/docker-bench-security
+          ref: 5a8d6434e6ebd70cb8bb465fce4ae5ed2a572eac
+          path: bench
+
+      # build image since dockerhub one is out of date
+      - name: Build Docker Bench for Security image
+        uses: docker/build-push-action@v3
+        with:
+          context: bench/
+          push: false
+          tags: docker-bench-security
+          load: true  # load build result into docker
+
+      - name: Run Docker Bench for Security
+        run: >
+          docker run --net host --pid host --userns host --cap-add audit_control
+          -e DOCKER_CONTENT_TRUST=$DOCKER_CONTENT_TRUST
+          -v /var/lib:/var/lib
+          -v /var/run/docker.sock:/var/run/docker.sock
+          -v /usr/lib/systemd:/usr/lib/systemd
+          -v /etc:/etc --label docker_bench_security
+          -v ${{ github.workspace }}/bench-logs:/usr/local/bin/log
+          docker-bench-security
+          -l log/log_file
+          -c container_images
+          -i intellabs/kafl
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: docker-bench-security
+          path: bench-logs/
 
   release:
     # this job makes an official Github release

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -206,7 +206,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
-  snyk-lint:
+  snyk-lint-dockerfile:
     needs: [build_image]
     runs-on: ubuntu-latest
     steps:
@@ -234,6 +234,35 @@ jobs:
       with:
         sarif_file: snyk.sarif
       if: ${{ failure() }}
+
+  snyk-lint-python:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.8'
+
+      - name: install dependencies
+        run: pip install -r requirements.txt
+        working-directory: deploy
+
+      - name: Copy requirements.txt at root of GITHUB_WORKSPACE for Snyk
+        run: cp deploy/requirements.txt .
+
+      - name: Run Snyk to check for vulnerabilities
+        uses: snyk/actions/python@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          args: --sarif-file-output=snyk.sarif
+
+      - name: Upload result to GitHub Code Scanning
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: snyk.sarif
+        if: ${{ failure() }}
 
   release:
     # this job makes an official Github release

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -167,6 +167,25 @@ jobs:
       - name: Run PT tests
         run: cargo test
 
+  build_image:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4.1.1
+        with:
+          images: intellabs/kafl
+
+      - name: Build image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: false
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
   release:
     # this job makes an official Github release
     needs: [ansible-lint, check-mode, local, remote, nyx-testing]

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -192,6 +192,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2.2.1
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v4.1.1
@@ -205,6 +208,9 @@ jobs:
           push: false
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          load: true  # load build result into docker
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
     
       # TODO: refactor in a separate in security.yml workflow
       - name: Run Snyk to check Docker image for vulnerabilities

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -198,14 +198,15 @@ jobs:
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
+          command: monitor
           image: ${{ steps.meta.outputs.tags }}
           args: --file=Dockerfile
         continue-on-error: true
 
-      - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
-        with:
-          sarif_file: snyk.sarif
+      # - name: Upload result to GitHub Code Scanning
+      #   uses: github/codeql-action/upload-sarif@v2
+      #   with:
+      #     sarif_file: snyk.sarif
 
   release:
     # this job makes an official Github release

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -203,6 +203,15 @@ jobs:
           load: true  # load build result into docker
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Update Docker Hub description
+        if: github.event_name == 'push'
+        uses: Wenzel/dockerhub-description@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: ${{ env.image_name }}
+          readme-filepath: ./.github/DOCKER.md
     
       # TODO: refactor in a separate in security.yml workflow
       - name: Run Snyk to check Docker image for vulnerabilities

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,9 +8,11 @@ on:
       - '*'
     paths-ignore:
       - '**/README.md'
+      - '.github/RELEASE.md'
   pull_request:
     paths-ignore:
       - '**/README.md'
+      - '.github/RELEASE.md'
 
 env:
   image_name: intellabs/kafl

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -202,8 +202,6 @@ jobs:
         with:
           command: monitor
           image: ${{ steps.meta.outputs.tags }}
-          args: --file=Dockerfile
-        continue-on-error: true
 
       # - name: Upload result to GitHub Code Scanning
       #   uses: github/codeql-action/upload-sarif@v2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,6 +12,9 @@ on:
     paths-ignore:
       - '**/README.md'
 
+env:
+  image_name: intellabs/kafl
+
 jobs:
   ansible-lint:
     runs-on: ubuntu-20.04
@@ -181,13 +184,20 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4.1.1
         with:
-          images: intellabs/kafl
+          images: ${{ env.image_name }}
+
+      - name: Login to Docker Hub
+        if: github.event_name == 'push'
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build image
         uses: docker/build-push-action@v3
         with:
           context: kafl/
-          push: false
+          push: ${{ github.event_name == 'push' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           load: true  # load build result into docker

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -37,13 +37,14 @@ jobs:
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
-          args: --sarif-file-output=snyk.sarif
-        continue-on-error: true
+          command: monitor
+      #     args: --sarif-file-output=snyk.sarif
+      #   continue-on-error: true
 
-      - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
-        with:
-          sarif_file: snyk.sarif
+      # - name: Upload result to GitHub Code Scanning
+      #   uses: github/codeql-action/upload-sarif@v2
+      #   with:
+      #     sarif_file: snyk.sarif
 
   hadolint:
       runs-on: ubuntu-latest

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,47 @@
+name: Security
+
+on:
+  push:
+    branches:
+      - 'master'
+    tags:
+      - '*'
+    paths-ignore:
+      - '**/README.md'
+  pull_request:
+    paths-ignore:
+      - '**/README.md'
+
+jobs:
+  snyk-lint-python:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        req_path: ["deploy/requirements.txt", "docs/requirements.txt"]
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.8'
+
+      - name: install dependencies
+        run: pip install -r ${{ matrix.req_path }}
+
+      - name: Copy requirements.txt at root of GITHUB_WORKSPACE for Snyk
+        run: cp ${{ matrix.req_path }} .
+
+      - name: Run Snyk to check for vulnerabilities
+        uses: snyk/actions/python@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          args: --sarif-file-output=snyk.sarif
+        continue-on-error: true
+
+      - name: Upload result to GitHub Code Scanning
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: snyk.sarif
+

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -45,3 +45,22 @@ jobs:
         with:
           sarif_file: snyk.sarif
 
+  hadolint:
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@v3
+
+        - name: Lint Dockerfile
+          id: hadolint
+          uses: hadolint/hadolint-action@v3.0.0
+          with:
+            # only consider errors, not warning or info level
+            failure-threshold: error
+            output-file: ${{ github.workspace }}/hadolint.out
+          continue-on-error: true
+
+        - name: Upload hadolint output artifact
+          uses: actions/upload-artifact@v3
+          with:
+            name: hadolint
+            path: ${{ github.workspace }}/hadolint.out

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.8'
+          python-version: '3.9'
 
       - name: install dependencies
         run: pip install -r ${{ matrix.req_path }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -8,9 +8,11 @@ on:
       - '*'
     paths-ignore:
       - '**/README.md'
+      - '.github/RELEASE.md'
   pull_request:
     paths-ignore:
       - '**/README.md'
+      - '.github/RELEASE.md'
 
 jobs:
   snyk-lint-python:

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN ./kafl/.venv/bin/pip install pyinstaller==${pyinstaller_version} && \
 RUN printf "%s\n" 'qemu_path: /usr/local/bin/qemu-system-x86_64' \
                   'ptdump_path: /usr/local/bin/ptdump' \
                   'radamsa_path: /usr/local/bin/radamsa' \
-                  'workdir: /workdir' >> settings.yaml
+                  'workdir: /mnt/workdir' >> settings.yaml
 
 FROM ${baseimage} as run
 # install QEMU
@@ -54,8 +54,9 @@ COPY --from=build /app/settings.yaml /etc/xdg/kAFL/
 # install shared libraries for QEMU
 RUN apt-get update && apt-get install -y --no-install-recommends libpixman-1-0 libpng16-16 libglib2.0-0 && apt-get clean
 
-# define kAFL WORKDIR volume (not to be confused with Dockerfile's WORKDIR)
-VOLUME ["/workdir"]
+WORKDIR /mnt/workdir
+# define kAFL WORKDIR as volume
+VOLUME ["/mnt/workdir"]
 
 # Setup env to run Dockerized Python app
 ENV LANG C.UF-8

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,10 @@ COPY --from=build /app/kafl/fuzzer/dist/kafl /usr/local/bin
 # install config file
 COPY --from=build /app/settings.yaml /etc/xdg/kAFL/
 
+# TODO: switch to full static QEMU build
+# install shared libraries for QEMU
+RUN apt-get update && apt-get install -y --no-install-recommends libpixman-1-0 libpng16-16 libglib2.0-0 && apt-get clean
+
 # define kAFL WORKDIR volume (not to be confused with Dockerfile's WORKDIR)
 VOLUME ["/workdir"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,8 +43,8 @@ COPY --from=build /app/kafl/qemu/x86_64-softmmu/qemu-system-x86_64 /usr/local/bi
 COPY --from=build /app/kafl/qemu/pc-bios/* /usr/local/share/qemu-firmware/
 # install radamsa
 COPY --from=build /app/kafl/radamsa/bin/radamsa /usr/local/bin
-# install ptdump
-COPY --from=build /app/kafl/libxdc/build/ptdump /usr/local/bin
+# install ptdump_static as ptdump
+COPY --from=build /app/kafl/libxdc/build/ptdump_static /usr/local/bin/ptdump
 # installer fuzzer
 COPY --from=build /app/kafl/fuzzer/dist/kafl /usr/local/bin
 # install config file

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,8 @@ RUN ./kafl/.venv/bin/pip install pyinstaller==${pyinstaller_version} && \
 # create kafl config file
 RUN echo "qemu_path: /usr/local/bin/qemu-system-x86_64" >> settings.yaml && \
     echo "ptdump_path: /usr/local/bin/ptdump" >> settings.yaml && \
-    echo "radamsa_path: /usr/local/bin/radamsa" >> settings.yaml
+    echo "radamsa_path: /usr/local/bin/radamsa" >> settings.yaml && \
+    echo "workdir: /workdir" >> settings.yaml
 
 FROM ${baseimage} as run
 # install QEMU
@@ -45,6 +46,9 @@ COPY --from=build /app/kafl/libxdc/build/ptdump /usr/local/bin
 COPY --from=build /app/kafl/fuzzer/dist/kafl /usr/local/bin
 # install config file
 COPY --from=build /app/settings.yaml /etc/xdg/kAFL/
+
+# define kAFL WORKDIR volume (not to be confused with Dockerfile's WORKDIR)
+VOLUME ["/workdir"]
 
 # Setup env to run Dockerized Python app
 ENV LANG C.UF-8

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,4 +68,7 @@ ENV PYTHONFAULTHANDLER 1
 # ensure that python output is sent straight to container logs without buffering
 ENV PYTHONUNBUFFERED 1
 
+# disable healthcheck
+HEALTHCHECK NONE
+# start kafl
 ENTRYPOINT ["kafl"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright (C) Intel Corporation, 2022
 # SPDX-License-Identifier: MIT
-ARG baseimage=debian:bullseye-slim
+ARG baseimage=debian:bullseye-slim$
 FROM ${baseimage} as build
 ARG pyinstaller_version=5.7.0
 
@@ -9,7 +9,7 @@ COPY . .
 
 # skip ghidra since it adds 1G to the final image,
 # and we don't use it for our fuzzing use case with Docker
-RUN apt-get update && apt-get install -y build-essential git python3 python3-venv && \
+RUN apt-get update && apt-get install -y --no-install-recommends build-essential git python3 python3-venv && \
     make deploy -- --tags fuzzer --skip-tags kernel,kvm_device,ghidra
 
 # create pyinstaller stub for executable Python packages

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,59 @@
+# Copyright (C) Intel Corporation, 2022
+# SPDX-License-Identifier: MIT
+ARG baseimage=debian:bullseye-slim
+FROM ${baseimage} as build
+ARG pyinstaller_version=5.7.0
+
+WORKDIR /app
+COPY . .
+
+# skip ghidra since it adds 1G to the final image,
+# and we don't use it for our fuzzing use case with Docker
+RUN apt-get update && apt-get install -y build-essential git python3 python3-venv && \
+    make deploy -- --tags fuzzer --skip-tags kernel,kvm_device,ghidra
+
+# create pyinstaller stub for executable Python packages
+# https://github.com/pyinstaller/pyinstaller/issues/2560
+RUN echo "from kafl_fuzzer.__main__ import main\nmain()" > ./kafl/fuzzer/stub.py
+# TODO: how to make pyinstaller detect Extension modules ?
+# move build/*/bitmap*.so as bitmap.so
+# include it in the pyinstaller executable
+RUN cd ./kafl/fuzzer && find build -name 'bitmap*.so' -exec mv {} bitmap.so \;
+# compile kafl as standalone python app
+RUN ./kafl/.venv/bin/pip install pyinstaller==${pyinstaller_version} && \
+    cd ./kafl/fuzzer  && /app/kafl/.venv/bin/pyinstaller \
+        --onefile --name kafl \
+        --add-data kafl_fuzzer/common/config/default_settings.yaml:kafl_fuzzer/common/config \
+        --add-data kafl_fuzzer/logging.yaml:kafl_fuzzer \
+        --add-binary bitmap.so:kafl_fuzzer/native \
+        stub.py
+
+# create kafl config file
+RUN echo "qemu_path: /usr/local/bin/qemu-system-x86_64" >> settings.yaml && \
+    echo "ptdump_path: /usr/local/bin/ptdump" >> settings.yaml && \
+    echo "radamsa_path: /usr/local/bin/radamsa" >> settings.yaml
+
+FROM ${baseimage} as run
+# install QEMU
+COPY --from=build /app/kafl/qemu/x86_64-softmmu/qemu-system-x86_64 /usr/local/bin/
+COPY --from=build /app/kafl/qemu/pc-bios/* /usr/local/share/qemu-firmware/
+# install radamsa
+COPY --from=build /app/kafl/radamsa/bin/radamsa /usr/local/bin
+# install ptdump
+COPY --from=build /app/kafl/libxdc/build/ptdump /usr/local/bin
+# installer fuzzer
+COPY --from=build /app/kafl/fuzzer/dist/kafl /usr/local/bin
+# install config file
+COPY --from=build /app/settings.yaml /etc/xdg/kAFL/
+
+# Setup env to run Dockerized Python app
+ENV LANG C.UF-8
+ENV LC_ALL C.UTF-8
+# don't write .pyc compiled code
+ENV PYTHONDONTWRITEBYTECODE 1
+# enable python stacktraces on segfaults
+ENV PYTHONFAULTHANDLER 1
+# ensure that python output is sent straight to container logs without buffering
+ENV PYTHONUNBUFFERED 1
+
+ENTRYPOINT ["kafl"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright (C) Intel Corporation, 2022
 # SPDX-License-Identifier: MIT
-ARG baseimage=debian:bullseye-slim
+ARG baseimage=python:3.11-slim
 FROM ${baseimage} as build
 ARG pyinstaller_version=5.7.0
 
@@ -9,7 +9,7 @@ COPY . .
 
 # skip ghidra since it adds 1G to the final image,
 # and we don't use it for our fuzzing use case with Docker
-RUN apt-get update && apt-get install -y --no-install-recommends build-essential git python3 python3-venv && \
+RUN apt-get update && apt-get install -y --no-install-recommends build-essential git libffi-dev && \
     make deploy -- --tags fuzzer --skip-tags kernel,kvm_device,ghidra
 
 # create pyinstaller stub for executable Python packages

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,9 @@ WORKDIR /mnt/workdir
 # define kAFL WORKDIR as volume
 VOLUME ["/mnt/workdir"]
 
+# remove setuid binaries (Docker Bench for Security check_4_8)
+RUN find / -path /proc -prune -perm /6000 -type f -exec chmod a-s {}  \;
+
 # Setup env to run Dockerized Python app
 ENV LANG C.UF-8
 ENV LC_ALL C.UTF-8

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # Copyright (C) Intel Corporation, 2022
 # SPDX-License-Identifier: MIT
+
 ARG baseimage=python:3.11-slim
 FROM ${baseimage} as build
 ARG pyinstaller_version=5.7.0
@@ -39,6 +40,7 @@ RUN printf "%s\n" 'qemu_path: /usr/local/bin/qemu-system-x86_64' \
                   'workdir: /mnt/workdir' >> settings.yaml
 
 FROM ${baseimage} as run
+LABEL org.opencontainers.image.licenses=MIT
 # install QEMU
 COPY --from=build /app/kafl/qemu/x86_64-softmmu/qemu-system-x86_64 /usr/local/bin/
 COPY --from=build /app/kafl/qemu/pc-bios/* /usr/local/share/qemu-firmware/

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,9 @@ COPY . .
 
 # skip ghidra since it adds 1G to the final image,
 # and we don't use it for our fuzzing use case with Docker
-RUN apt-get update && apt-get install -y --no-install-recommends build-essential git libffi-dev && \
-    make deploy -- --tags fuzzer --skip-tags kernel,kvm_device,ghidra
+RUN echo '{"qemu_build_type": "full_static"}' > deploy/play_params.json && \
+        apt-get update && apt-get install -y --no-install-recommends build-essential git libffi-dev && \
+        make deploy -- --tags fuzzer --skip-tags kernel,kvm_device,ghidra --extra-vars "@play_params.json"
 
 # create pyinstaller stub for executable Python packages
 # https://github.com/pyinstaller/pyinstaller/issues/2560
@@ -49,10 +50,6 @@ COPY --from=build /app/kafl/libxdc/build/ptdump_static /usr/local/bin/ptdump
 COPY --from=build /app/kafl/fuzzer/dist/kafl /usr/local/bin
 # install config file
 COPY --from=build /app/settings.yaml /etc/xdg/kAFL/
-
-# TODO: switch to full static QEMU build
-# install shared libraries for QEMU
-RUN apt-get update && apt-get install -y --no-install-recommends libpixman-1-0 libpng16-16 libglib2.0-0 && apt-get clean
 
 WORKDIR /mnt/workdir
 # define kAFL WORKDIR as volume

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ FROM ${baseimage} as run
 LABEL org.opencontainers.image.licenses=MIT
 # install QEMU
 COPY --from=build /app/kafl/qemu/x86_64-softmmu/qemu-system-x86_64 /usr/local/bin/
-COPY --from=build /app/kafl/qemu/pc-bios/* /usr/local/share/qemu-firmware/
+COPY --from=build /app/kafl/qemu/pc-bios/*.bin /usr/local/share/qemu-firmware/
 # install radamsa
 COPY --from=build /app/kafl/radamsa/bin/radamsa /usr/local/bin
 # install ptdump_static as ptdump

--- a/deploy/intellabs/kafl/roles/fuzzer/tasks/main.yml
+++ b/deploy/intellabs/kafl/roles/fuzzer/tasks/main.yml
@@ -1,12 +1,3 @@
-- name: Ensure minimal deps are available
-  ansible.builtin.package:
-    name: "{{ item }}"
-    state: present
-  become: true
-  with_items:
-    - dpkg
-    - sudo
-
 - name: Ensure kAFL parent directory exists
   ansible.builtin.file:
     path: "{{ kafl_install_root | dirname }}"

--- a/deploy/intellabs/kafl/roles/kernel/tasks/main.yml
+++ b/deploy/intellabs/kafl/roles/kernel/tasks/main.yml
@@ -5,6 +5,7 @@
   ansible.builtin.package:
     name:
       - build-essential
+      - dpkg
   become: true
 
 - name: Create temporary directory


### PR DESCRIPTION
Reopen this PR from #104 

This PR Dockerize the kAFL fuzzer.
It's based on https://github.com/Wenzel/kAFL/tree/docker_workspace, updated with the new Ansible deployment.

To build the image:
```shell
docker build -t kafl .
```

To apply that image on [fuzzing the linux kernel tutorial](https://intellabs.github.io/kAFL/tutorials/fuzzing_linux_kernel.html)
*Make sure to create the workdir beforehand*, otherwise the Docker daemon will create it as `root:root` and `kafl` will fail.
```shell
docker run \
        -ti --rm \
        --device /dev/kvm \
        -v $(pwd)/kafl_config.yaml:/mnt/kafl_config.yaml \
        -v /dev/shm/kafl:/mnt/workdir \
        -v $(pwd)/linux-guest/arch/x86/boot/bzImage:/mnt/kernel \
        -e KAFL_CONFIG_FILE=/mnt/kafl_config.yaml \
        --user $(id -u):$(id -g) \
        --group-add $(getent group kvm | cut -d: -f3) \
        kafl \
        --purge \
        -w /mnt/workdir \
        --redqueen --grimoire -D --radamsa \
        --kernel /mnt/kernel \
        -t 0.1 -ts 0.01 -m 512 --log-crashes -p 2
````

# TODO

- [ ] document new installation (kernel + docker + pull image)
- [ ] add related dockerhub badges