### PR TITLE
fuzzer: remove libgraphviz-dev dependency

### DIFF
--- a/deploy/intellabs/kafl/roles/fuzzer/tasks/main.yml
+++ b/deploy/intellabs/kafl/roles/fuzzer/tasks/main.yml
@@ -19,7 +19,6 @@
     name: "{{ item }}"
   become: true
   with_items:
-    - libgraphviz-dev
     - python3-dev
     - python3-venv
     - python3-setuptools


### PR DESCRIPTION
Following https://github.com/IntelLabs/kafl.fuzzer/pull/43