### PR TITLE
better getting started

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ ifneq ($(filter $(firstword $(MAKECMDGOALS)), $(ALL_TARGETS)),)
   $(eval $(EXTRA_ARGS):;@:)
 endif
 
-all: deploy
+all: help
 
 # User targets
 #---------------
@@ -33,6 +33,24 @@ env: SHELL:=bash
 env: kafl/env.sh
 	@echo "Entering environment in sub-shell. Exit with 'Ctrl-d'."
 	@PROMPT_COMMAND='source kafl/env.sh; unset PROMPT_COMMAND' $(SHELL)
+
+define HELP_TEXT
+Manage kAFL installation.
+
+  User actions:
+    deploy:\tFull installation (download, build, install)
+    env:\tActivate installation (shell env + python venv)
+    clean:\tPurge ansible installation (to force re-deploy)
+
+  Developer actions:
+    update:\tUpdate cloned git repositories
+    build:\tExecute component build steps only
+endef
+export HELP_TEXT
+
+help:
+	@echo "$$HELP_TEXT"
+
 
 # Developer targets
 #------------------

--- a/README.md
+++ b/README.md
@@ -39,9 +39,35 @@ modifications.
 
 For details on Redqueen, Grimoire, [_IJON_](https://github.com/RUB-SysSec/ijon), Nyx, please visit [nyx-fuzz.com](https://nyx-fuzz.com).
 
+
+## Requirements
+
+- **Intel Skylake or later:** The setup requires a Gen-6 or newer Intel CPU (for
+  Intel PT) and adequate system memory (~2GB RAM per CPU)
+
+- **Patched Host Kernel:** A modified Linux host kernel will be installed as part
+  of the setup. Running kAFL inside a VM may work starting IceLake or later CPU.
+
+- **Recent Debian/Ubuntu:** The installation and tutorials are
+  tested for recent Ubuntu LTS (>=20.04) and Debian (>=bullseye).
+
+
 ## Getting Started
 
-➡️ The official [tutorial](https://IntelLabs.github.io/kAFL/tutorials/introduction.html) will walk you through your first steps
-to setup kAFL and fuzz the Linux kernel !
+Once you have python3-venv and make installed, you can install kAFL using `make deploy`:
 
-_Note: kAFL requires a Gen-6 Skylake CPU, or newer._
+```
+sudo apt install python3-venv make git
+git clone https://github.com/IntelLabs/kAFL.git
+cd kAFL; make deploy
+```
+
+Installation make take some time and require a reboot to update your kernel.
+
+Check the detailed [installation guide](https://intellabs.github.io/kAFL/tutorials/installation.html) in case
+of trouble, or the [deployment guide](https://intellabs.github.io/kAFL/reference/deployment.html) for detailed
+information and customizing the kAFL setup for your project.
+
+As a first fuzzing example, we recommend [Fuzzing the Linux Kernel](https://intellabs.github.io/kAFL/tutorials/fuzzing_linux_kernel.html).
+
+


### PR DESCRIPTION
Current main page is rather unhelpful with getting started.

After fancy expose of features, the user is lead to a different page which (in my case) has some text but no obvious links to next step. Once I find the "next" button at the far bottom of the page, I get a bit overwhelming full page installation guide with lots of colorful boxes. Its quite difficult to fish out requirements and 2-3 relevant commands between all the boxes and highlights. 

- this patch adds requirements + getting started section back in
- suggest to revise the installation guide for better overview + in depth background on possible problems, like checking for HW support
- tutorials should start with 'make env' (too much for this 'getting started' section)

