### PR TITLE
qemu: add qemu_build_type default option

### DIFF
--- a/deploy/intellabs/kafl/roles/qemu/defaults/main.yml
+++ b/deploy/intellabs/kafl/roles/qemu/defaults/main.yml
@@ -1,3 +1,4 @@
 qemu_url: 'https://github.com/IntelLabs/kafl.qemu'
 qemu_revision: 'kafl_stable'
 qemu_root: "{{ kafl_install_root }}/qemu"
+qemu_build_type: "static"

--- a/deploy/intellabs/kafl/roles/qemu/tasks/main.yml
+++ b/deploy/intellabs/kafl/roles/qemu/tasks/main.yml
@@ -31,7 +31,7 @@
     - clone
 
 - name: Build QEMU
-  ansible.builtin.command: ./compile_qemu_nyx.sh static
+  ansible.builtin.command: ./compile_qemu_nyx.sh {{ qemu_build_type }}
   args:
     chdir: "{{ qemu_root }}"
   environment:


### PR DESCRIPTION
Following https://github.com/IntelLabs/kafl.qemu/pull/3

This will help to create a clean Docker image with only static binaries