### PR TITLE
docker: include QEMU pc-bios/*.rom files

### DIFF
--- a/.github/RELEASE.md
+++ b/.github/RELEASE.md
@@ -1,25 +1,18 @@
 # 🌟 Features
 
-- Add Sphinx-based documentation system hosted at [https://IntelLabs.github.io/kAFL/](https://IntelLabs.github.io/kAFL/) (https://github.com/IntelLabs/kAFL/pull/122)
-- Add Dockerfile to build kAFL as Docker image (#136)
-- Published official [intellabs/kafl](https://hub.docker.com/r/intellabs/kafl) Docker image on [Dockerhub](https://hub.docker.com/) (#136, #163)
+/
 
 # ✨ Improvements
 
-- Follow [kafl_fuzzer](https://github.com/IntelLabs/kafl.fuzzer) changelog style (https://github.com/IntelLabs/kAFL/pull/123)
-- Require `Python 3.9` and upgrading to latest `Ansible 7.1.0` (#156)
+/
 
 # 🔧 Fixes
 
-/
+- include QEMU ROM files in Docker image (#168)
 
 # 📖 Documentation
 
-- Installation, Linux kernel fuzzing tutorial, deployment and hypercall API (https://github.com/IntelLabs/kAFL/pull/122, https://github.com/IntelLabs/kAFL/pull/127, #135)
-- Reference docs on workdir layout and kAFL GUI (#129)
-- Moved [kafl.fuzzer/docs/fuzzer_configuration.md](https://github.com/IntelLabs/kafl.fuzzer/blob/2367ccc39a5dfe873b6fc5ca40accab7b358cb4c/docs/fuzzer_configuration.md) as [reference/fuzzer_configuration](https://intellabs.github.io/kAFL/reference/fuzzer_configuration.html) (#152)
-- Document all configuration keys (#154)
-- Document Docker image based setup (#165)
+/
 
 # 🧰 Behind the scenes
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ FROM ${baseimage} as run
 LABEL org.opencontainers.image.licenses=MIT
 # install QEMU
 COPY --from=build /app/kafl/qemu/x86_64-softmmu/qemu-system-x86_64 /usr/local/bin/
-COPY --from=build /app/kafl/qemu/pc-bios/*.bin /usr/local/share/qemu-firmware/
+COPY --from=build /app/kafl/qemu/pc-bios/*.bin /app/kafl/qemu/pc-bios/*.rom /usr/local/share/qemu-firmware/
 # install radamsa
 COPY --from=build /app/kafl/radamsa/bin/radamsa /usr/local/bin
 # install ptdump_static as ptdump


### PR DESCRIPTION
Linux kernel example uses a `virtio-net` device, which requires `pc-bios/efi-virtio.rom` file not included in the final Docker image.
This PR fixes that.