### PR TITLE
ci: push use latest tag for intellabs/kafl image

### DIFF
--- a/.github/RELEASE.md
+++ b/.github/RELEASE.md
@@ -9,6 +9,7 @@
 # 🔧 Fixes
 
 - include QEMU ROM files in Docker image (#168)
+- push `intellabs/kafl:latest` tag by default (#169)
 
 # 📖 Documentation
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -187,6 +187,8 @@ jobs:
         uses: docker/metadata-action@v4.1.1
         with:
           images: ${{ env.image_name }}
+          flavor: |
+            latest=true
 
       - name: Build image
         uses: docker/build-push-action@v3

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -197,7 +197,7 @@ jobs:
           push: false
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          loads: true
+          load: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
 


### PR DESCRIPTION
push `intellabs/kafl:latest` tag by default