### PR TITLE
ci: deprecate ubuntu-18.04 runner

### DIFF
--- a/.github/RELEASE.md
+++ b/.github/RELEASE.md
@@ -19,4 +19,5 @@
 
 # 🧰 Behind the scenes
 
-/
+- deprecate NodeJSv12 based actions (#180)
+- deprecate Ubuntu-18.04 runner (#181)

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -58,7 +58,7 @@ jobs:
   local:
     strategy:
         matrix:
-            os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
+            os: [ubuntu-20.04, ubuntu-22.04]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/