### PR TITLE
Conditionally install required tooling to build Windows VM template in order to run Windows examples

### DIFF
--- a/.github/RELEASE.md
+++ b/.github/RELEASE.md
@@ -4,7 +4,7 @@
 
 # ✨ Improvements
 
-/
+- Setup required tooling for Windows template used by examples (#205
 
 # 🔧 Fixes
 
@@ -13,6 +13,8 @@
 # 📖 Documentation
 
 
+- add `examples-windows-template` tag (#205)
 
 # 🧰 Behind the scenes
 
+/

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Run ansible-lint
         working-directory: deploy
         run: |
-          ./venv/bin/ansible-lint -x 'meta-no-info' -x galaxy -x 'yaml[octal-values]' -x no-changed-when --exclude venv
+          ./venv/bin/ansible-lint -x 'meta-no-info' -x galaxy -x 'yaml[octal-values]' -x no-changed-when -x risky-file-permissions --exclude venv
 
   check-mode:
     runs-on: ubuntu-20.04

--- a/README.md
+++ b/README.md
@@ -104,8 +104,7 @@ Other targets are available such as:
 
 - [UEFI OVMF](https://github.com/IntelLabs/kafl.targets/tree/master/uefi_ovmf_64)
 - [Linux userspace](https://github.com/IntelLabs/kafl.targets/tree/master/linux-user)
-- [Windows userspace](https://github.com/IntelLabs/kafl.targets/tree/master/windows_x86_64-userspace)
-- [Windows driver](https://github.com/IntelLabs/kafl.targets/tree/master/windows_x86_64)
+- [Windows driver/userspace](https://github.com/IntelLabs/kafl.targets/tree/master/windows_x86_64)
 
 A improved documentation is under work for these targets.
 

--- a/deploy/intellabs/kafl/roles/examples/tasks/main.yml
+++ b/deploy/intellabs/kafl/roles/examples/tasks/main.yml
@@ -7,3 +7,7 @@
     force: "{{ force_clone }}"
   tags:
     - clone
+
+- name: Import template windows tasks
+  ansible.builtin.import_tasks: template_windows.yml
+  when: "'examples-template-windows' in ansible_run_tags"

--- a/deploy/intellabs/kafl/roles/examples/tasks/template_windows.yml
+++ b/deploy/intellabs/kafl/roles/examples/tasks/template_windows.yml
@@ -1,0 +1,71 @@
+- name: Install MinGW GNU C Compiler
+  ansible.builtin.apt:
+    name: gcc-mingw-w64-x86-64
+  become: true
+
+- name: Check hashicorp repo key
+  ansible.builtin.stat:
+    path: /usr/share/keyrings/hashicorp-archive-keyring.gpg
+  register: key_stat
+
+- name: Add Hashicorp repo key
+  when: not key_stat.stat.exists
+  block:
+    - name: Download Hashicorp key
+      ansible.builtin.get_url:
+        url: https://apt.releases.hashicorp.com/gpg
+        dest: /tmp/hashicorp.key
+
+    - name: Unpack GPG key
+      ansible.builtin.shell: set -o pipefail && cat /tmp/hashicorp.key | gpg --batch --yes --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
+      become: true
+
+    - name: Remove temp file
+      ansible.builtin.file:
+        path: /tmp/hashicorp.key
+        state: absent
+
+- name: Add Hashicorp repository
+  ansible.builtin.apt_repository:
+    repo: "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com {{ ansible_lsb.codename }} main"
+    filename: hashicorp
+    state: present
+  become: true
+
+- name: Ensure packer and vagrant are installed
+  ansible.builtin.apt:
+    name:
+      - packer
+      # vagrant-host-shell plugin doesn't support 2.3.7-1 or newer
+      - vagrant=2.3.6-1
+      # dependency for vagrant plugins
+      - ruby-dev
+      # dependency for vagrant-libvirt
+      - libvirt-dev
+    update_cache: true
+  become: true
+
+- name: Install vagrant plugins
+  ansible.builtin.command: vagrant plugin install vagrant-libvirt vagrant-host-shell
+
+- name: Ensure /etc/qemu exists
+  ansible.builtin.file:
+    path: /etc/qemu
+    state: directory
+  become: true
+
+- name: Ensure /etc/qemu/bridge.conf is configured to allow virbr0
+  ansible.builtin.lineinfile:
+    path: /etc/qemu/bridge.conf
+    line: 'allow virbr0'
+    mode: 0644
+    group: "{{ ansible_user_id }}"
+    backup: true
+    create: true
+  become: true
+
+- name: Ensure qemu-bridge-helper is setuid
+  ansible.builtin.file:
+    path: /usr/lib/qemu/qemu-bridge-helper
+    mode: 'u+s'
+  become: true

--- a/docs/source/reference/deployment.md
+++ b/docs/source/reference/deployment.md
@@ -33,11 +33,11 @@ Nothing else !
 
 | Target   | Description                                                                                                                    | EXTRA_ARGS |
 | -------- | ------------------------------------------------------------------------------------------------------------------------------ | ---------- |
-| `deploy` | Deploys kAFL components according to the playbook and the `deploy/inventory` file. Will be deployed on `localhost` by default. | ☑️         |
+| `deploy` | Deploys kAFL components according to the playbook and the `deploy/inventory` file. Will be deployed on `localhost` by default. | ☑️          |
 | `env`    | Enters a new sub-shell with the kAFL environment variables set.                                                                |            |
 | `clean`  | Removes the _virtualenv_ `deploy/venv`                                                                                         |            |
-| `update` | Forces to `git pull` on every repository managed by the playbook. Developer oriented target. Uses the `clone` _Ansible_ tag.   | ☑️         |
-| `build`  | Rebuilds every component that can be built. Developer oriented target. Uses the `build` _Ansible_ tag.                         | ☑️         |
+| `update` | Forces to `git pull` on every repository managed by the playbook. Developer oriented target. Uses the `clone` _Ansible_ tag.   | ☑️          |
+| `build`  | Rebuilds every component that can be built. Developer oriented target. Uses the `build` _Ansible_ tag.                         | ☑️          |
 
 
 
@@ -75,20 +75,21 @@ A set of [_Ansible_ tags](https://docs.ansible.com/ansible/latest/user_guide/pla
 
 They can be toggled or skipped with the [`--tags`](https://docs.ansible.com/ansible/latest/cli/ansible-playbook.html#cmdoption-ansible-playbook-2) and [`--skip-tags`](https://docs.ansible.com/ansible/latest/cli/ansible-playbook.html#cmdoption-ansible-playbook-skip-tags) _Ansible_ command line parameters, and directly added from the makefile target via `EXTRA_ARGS` feature (described previously).
 
-| Tag              | Description                                                                                                                    |
-| ---------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| `kernel`         | Selects the [kernel](https://github.com/IntelLabs/kafl.linux) tasks                                                            |
-| `radamsa`        | Selects the [radamsa](https://gitlab.com/akihe/radamsa) tasks                                                                  |
-| `capstone`       | Selects the [capstone](https://github.com/aquynh/capstone) tasks                                                               |
-| `libxdc`         | Selects the [libxdc](https://github.com/IntelLabs/kafl.libxdc) tasks                                                           |
-| `qemu`           | Selects the [QEMU](https://github.com/IntelLabs/kafl.qemu) tasks                                                               |
-| `fuzzer`         | Selects the [fuzzer](https://github.com/IntelLabs/kafl.fuzzer) tasks                                                           |
-| `hardware_check` | Selects the hardware/kernel requirements checking tasks. Introduced to be skipped on the CI runs.                                     |
-| `kvm_device`     | Selects the tasks related to fixing permissions on the KVM node device. Introduced to be skipped on the CI runs.               |
-| `reboot_kernel`  | Selects the task responsible for rebooting the remote node after kernel installation. Introduced to be skipped on the CI runs. |
-| `update_grub`    | Selects the tasks related to GRUB entry update after kernel installation. Introduced to be skipped on the CI runs.             |
-| `build`          | Selects all tasks where a component can be rebuild (`QEMU`, `libxdc`, etc ...). Developer oriented tag.                        |
-| `clone`          | Selects all tasks where a repository is cloned. Developer oriented tag.                                                        |
+| Tag                         | Description                                                                                                                                  |
+| --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `kernel`                    | Selects the [kernel](https://github.com/IntelLabs/kafl.linux) tasks                                                                          |
+| `radamsa`                   | Selects the [radamsa](https://gitlab.com/akihe/radamsa) tasks                                                                                |
+| `capstone`                  | Selects the [capstone](https://github.com/aquynh/capstone) tasks                                                                             |
+| `libxdc`                    | Selects the [libxdc](https://github.com/IntelLabs/kafl.libxdc) tasks                                                                         |
+| `qemu`                      | Selects the [QEMU](https://github.com/IntelLabs/kafl.qemu) tasks                                                                             |
+| `fuzzer`                    | Selects the [fuzzer](https://github.com/IntelLabs/kafl.fuzzer) tasks                                                                         |
+| `hardware_check`            | Selects the hardware/kernel requirements checking tasks. Introduced to be skipped on the CI runs.                                            |
+| `kvm_device`                | Selects the tasks related to fixing permissions on the KVM node device. Introduced to be skipped on the CI runs.                             |
+| `reboot_kernel`             | Selects the task responsible for rebooting the remote node after kernel installation. Introduced to be skipped on the CI runs.               |
+| `update_grub`               | Selects the tasks related to GRUB entry update after kernel installation. Introduced to be skipped on the CI runs.                           |
+| `build`                     | Selects all tasks where a component can be rebuild (`QEMU`, `libxdc`, etc ...). Developer oriented tag.                                      |
+| `clone`                     | Selects all tasks where a repository is cloned. Developer oriented tag.                                                                      |
+| `examples-template-windows` | Installs the required tooling to build the Windows template and run the examples. (Packer, Vagrant, agrant-plugins, qemu-bridge-helper, ...) |
 
 
 :::{note}


### PR DESCRIPTION
Updates the playbook with a new section under `examples` role, conditioned by `examples-template-windows` tag being specified.

installs the following packages:
- vagrant 2.3.6-1
- packer
- gcc-mingw-w64-x86-64
- libvirt-dev
- ruby-dev

and setup the qemu-bridge-helper as setuid, which is required to allow vagrant to setup the network in `qemu:///session` mode

Related: https://github.com/IntelLabs/kafl.targets/pull/21