### PR TITLE
docker: fix build directory missing to find bitmap.so

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN printf "%s\n" 'from kafl_fuzzer.__main__ import main' \
 # TODO: how to make pyinstaller detect Extension modules ?
 # move build/*/bitmap*.so as bitmap.so
 # include it in the pyinstaller executable
-RUN cd ./kafl/fuzzer && find build -name 'bitmap*.so' -exec mv {} bitmap.so \;
+RUN cd ./kafl/fuzzer && find . -name 'bitmap*.so' -exec mv {} bitmap.so \;
 # compile kafl as standalone python app
 RUN ./kafl/.venv/bin/pip install pyinstaller==${pyinstaller_version} && \
     cd ./kafl/fuzzer  && /app/kafl/.venv/bin/pyinstaller \


### PR DESCRIPTION
Fix issue when using the latest `python3.11-slim` image.

When installing the kafl_fuzzer in editable mode, a `build` directory is not produced anymore, which breaks the Dockerfile when searching for `bitmap.so`

Now searching in the whole `kafl_fuzzer` repo.