### PR TITLE
qemu: pin qemu_revision to a specific tag, not branch

### DIFF
--- a/.github/RELEASE.md
+++ b/.github/RELEASE.md
@@ -8,7 +8,8 @@
 
 # 🔧 Fixes
 
-/
+- Security fixes (#215, #217)
+- Switch QEMU revision pinning to a tag instead of a branch (#214)
 
 # 📖 Documentation
 

--- a/deploy/intellabs/kafl/roles/qemu/defaults/main.yml
+++ b/deploy/intellabs/kafl/roles/qemu/defaults/main.yml
@@ -1,4 +1,4 @@
 qemu_url: 'https://github.com/IntelLabs/kafl.qemu'
-qemu_revision: 'kafl_stable'
+qemu_revision: 'v0.7'
 qemu_root: "{{ kafl_install_root }}/qemu"
 qemu_build_type: "static"


### PR DESCRIPTION
Following recent QEMU [`v0.7`](https://github.com/IntelLabs/kafl.qemu/releases/tag/v0.7) release, pin the tag instead of tracking a branch.
