### PR TITLE
docs: fix range_submit hypercall buffer indexes

### DIFF
--- a/docs/source/reference/hypercall_api.md
+++ b/docs/source/reference/hypercall_api.md
@@ -370,9 +370,9 @@ obtain as part of agent initialization.
 caption: Example
 ---
 uint64_t buffer[3] = {0};
-buffer[0] = 0; // IP filter index [0-3]
-buffer[1] = 0xfffff8010e0b0000 // low range
-buffer[2] = 0xfffff8010e0b7000 // high range
+buffer[0] = 0xfffff8010e0b0000 // low range
+buffer[1] = 0xfffff8010e0b7000 // high range
+buffer[2] = 0; // IP filter index [0-3]
 kAFL_hypercall(HYPERCALL_KAFL_RANGE_SUBMIT, (uint64_t)buffer);
 ```
 


### PR DESCRIPTION
reported by @Gehim12
related #229 

Implementation in QEMU:
https://github.com/IntelLabs/kafl.qemu/blob/kafl_stable/nyx/hypercall/hypercall.c#L296
```c
    if (buffer[0] != 0 && buffer[1] != 0) {
        GET_GLOBAL_STATE()->pt_ip_filter_a[buffer[2]]          = buffer[0];
        GET_GLOBAL_STATE()->pt_ip_filter_b[buffer[2]]          = buffer[1];
        GET_GLOBAL_STATE()->pt_ip_filter_configured[buffer[2]] = true;
        nyx_debug_p(CORE_PREFIX, "Configured range register IP%ld: 0x%08lx-0x%08lx\n",
                    buffer[2], buffer[0], buffer[1]);
```