### PR TITLE
add dvkm example

### DIFF
--- a/deploy/intellabs/kafl/roles/examples/defaults/main.yml
+++ b/deploy/intellabs/kafl/roles/examples/defaults/main.yml
@@ -1,2 +1,5 @@
 examples_url: https://github.com/IntelLabs/kafl.targets
 examples_root: "{{ kafl_install_root }}/examples"
+
+dvkm_sub_path: linux-user/dvkm/Damn_Vulnerable_Kernel_Module
+linux_agent_sub_path: linux-user/linux_kafl_agent

--- a/deploy/intellabs/kafl/roles/examples/tasks/dvkm.yml
+++ b/deploy/intellabs/kafl/roles/examples/tasks/dvkm.yml
@@ -1,0 +1,15 @@
+- name: Install required packages
+  ansible.builtin.apt:
+    # required for lddtree
+    name: pax-utils
+  become: true
+
+- name: Clone required submodules
+  ansible.builtin.command: >-
+    "git submodule update --init --depth 200
+    --jobs {{ ansible_processor_nproc }}
+    {{ dvkm_sub_path }}
+    {{ linux_agent_sub_path }}"
+    # noqa: command-instead-of-module
+  args:
+    chdir: "{{ examples_root }}"

--- a/deploy/intellabs/kafl/roles/examples/tasks/main.yml
+++ b/deploy/intellabs/kafl/roles/examples/tasks/main.yml
@@ -11,3 +11,7 @@
 - name: Import template windows tasks
   ansible.builtin.import_tasks: template_windows.yml
   when: "'examples-template-windows' in ansible_run_tags"
+
+- name: Import dvkm tasks
+  ansible.builtin.import_tasks: dvkm.yml
+  when: "'examples-linux-dvkm' in ansible_run_tags"

--- a/docs/source/reference/deployment.md
+++ b/docs/source/reference/deployment.md
@@ -90,7 +90,7 @@ They can be toggled or skipped with the [`--tags`](https://docs.ansible.com/ansi
 | `build`                     | Selects all tasks where a component can be rebuild (`QEMU`, `libxdc`, etc ...). Developer oriented tag.                                      |
 | `clone`                     | Selects all tasks where a repository is cloned. Developer oriented tag.                                                                      |
 | `examples-template-windows` | Installs the required tooling to build the Windows template and run the examples. (Packer, Vagrant, agrant-plugins, qemu-bridge-helper, ...) |
-
+| `examples-dvkm`             | Installs the required packages and submodules to use the Damn Vulnerable Kernel Module linux example                                         |
 
 :::{note}
 You can list available tags with


### PR DESCRIPTION
This PR goes with another kafl.targets PR that adds a new example based on the Damn Vulnerable Kernel Module