### PR TITLE
docker: upgrade pyinstaller to v6.1.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 
 ARG baseimage=python:3.11-slim
 FROM ${baseimage} as build
-ARG pyinstaller_version=5.7.0
+ARG pyinstaller_version=6.1.0
 
 WORKDIR /app
 COPY . .


### PR DESCRIPTION
Fix #248 

```python
[7] Module object for pyimod02_importers is NULL!
Traceback (most recent call last):
  File "PyInstaller/loader/pyimod02_importers.py", line 22, in <module>
  File "pathlib.py", line 14, in <module>
  File "urllib/parse.py", line 40, in <module>
ModuleNotFoundError: No module named 'ipaddress'
Traceback (most recent call last):
  File "PyInstaller/loader/pyiboot01_bootstrap.py", line 17, in <module>
ModuleNotFoundError: No module named 'pyimod02_importers'
[7] Failed to execute script 'pyiboot01_bootstrap' due to unhandled exception!
```