### PR TITLE
deploy: update QEMU and libxdc to fix 6.0 regression

### DIFF
--- a/.github/RELEASE.md
+++ b/.github/RELEASE.md
@@ -16,6 +16,7 @@
 - `kafl.targets`: simplify linux kernel tutorial and use predefined load path for kAFL configuration ([`kafl.targets#23`](https://github.com/IntelLabs/kafl.targets/pull/23))
 - examples role: fix shell used to unpacking GPG key (#233)
 - examples role: install missing qemu-system-x86 package (#234)
+- libxdc/QEMU: fix regression observed with the 6.0 Nyx kernel (#253)
 
 # 📖 Documentation
 

--- a/deploy/intellabs/kafl/roles/libxdc/defaults/main.yml
+++ b/deploy/intellabs/kafl/roles/libxdc/defaults/main.yml
@@ -1,2 +1,2 @@
 libxdc_url: 'https://github.com/IntelLabs/kafl.libxdc'
-libxdc_revision: kafl_stable
+libxdc_revision: 'v0.2'

--- a/deploy/intellabs/kafl/roles/qemu/defaults/main.yml
+++ b/deploy/intellabs/kafl/roles/qemu/defaults/main.yml
@@ -1,4 +1,4 @@
 qemu_url: 'https://github.com/IntelLabs/kafl.qemu'
-qemu_revision: 'v0.7'
+qemu_revision: 'v0.8'
 qemu_root: "{{ kafl_install_root }}/qemu"
 qemu_build_type: "static"


### PR DESCRIPTION
Fixes https://github.com/IntelLabs/kafl.linux/issues/10

Upgrade:
- `kafl.qemu` to [`v0.8`](https://github.com/IntelLabs/kafl.qemu/releases/tag/v0.8)
- `kafl.libxdc` to [`v0.2`](https://github.com/IntelLabs/kafl.libxdc/releases/tag/v0.2) (pinned)