### PR TITLE
docs: fix hypercall argument for DUMP_FILE

### DIFF
--- a/.github/RELEASE.md
+++ b/.github/RELEASE.md
@@ -22,7 +22,7 @@
 
 - Misc fixes (#213)
 - Linux kernel tutorial: use implicit IP filters from snapshot metadata: (https://intellabs.github.io/kAFL/reference/hypercall_api.html#range-submit) (#216)
-
+- Fix `DUMP_FILE` hypercall argument (#254) (Thanks @sangjun !)
 
 # 🧰 Behind the scenes
 

--- a/docs/source/reference/hypercall_api.md
+++ b/docs/source/reference/hypercall_api.md
@@ -517,7 +517,7 @@ kafl_dump_file_t dump_file = {
   .bytes = 4096,
   .append = 0
 };
-kAFL_hypercall(HYPERCALL_KAFL_DUMP_FILE, (uint64_t)buffer);
+kAFL_hypercall(HYPERCALL_KAFL_DUMP_FILE, (uintptr_t)&dump_file);
 ```
 
 ### `USER_FAST_ACQUIRE`


### PR DESCRIPTION
Reported by @sangjun
Fixed #251 