### PR TITLE
Fix libvirt issue while make init

### DIFF
--- a/deploy/intellabs/kafl/roles/examples/tasks/template_windows.yml
+++ b/deploy/intellabs/kafl/roles/examples/tasks/template_windows.yml
@@ -76,3 +76,29 @@
     path: /usr/lib/qemu/qemu-bridge-helper
     mode: 'u+s'
   become: true
+
+
+- name: Install required for init
+  ansible.builtin.apt:
+    # https://askubuntu.com/questions/1225216/failed-to-connect-socket-to-var-run-libvirt-libvirt-sock
+    name: 
+      - pax-utils
+      - qemu
+      - qemu-kvm
+      - libvirt-clients
+      - libvirt-daemon-system
+      - virtinst
+      - bridge-utils
+    state: present
+  become: true
+  tags:
+    - virtualization_packages
+
+- name: Enable and start libvirtd service
+  ansible.builtin.systemd:
+    name: libvirtd
+    enabled: yes
+    state: started
+  become: true
+  tags:
+    - libvirtd_service


### PR DESCRIPTION
Hi, i'm sangjun who is very interested in this project.


When i'm following [kAFL windows tutorial](https://intellabs.github.io/kAFL/tutorials/windows/windows_template.html), i found some problem.

## libvirt issue
1. I think you should change your ansible yaml like below: There is a libvirt issue in the make init step.
```
b@b:~/kAFL-patch$ git diff HEAD
diff --git a/deploy/intellabs/kafl/roles/examples/tasks/template_windows.yml b/deploy/intellabs/kafl/roles/examples/tasks/template_windows.yml
index 1338d39..4324f7d 100644
--- a/deploy/intellabs/kafl/roles/examples/tasks/template_windows.yml
+++ b/deploy/intellabs/kafl/roles/examples/tasks/template_windows.yml
@@ -76,3 +76,29 @@
     path: /usr/lib/qemu/qemu-bridge-helper
     mode: 'u+s'
   become: true
+
+
+- name: Install required for init
+  ansible.builtin.apt:
+    # https://askubuntu.com/questions/1225216/failed-to-connect-socket-to-var-run-libvirt-libvirt-sock
+    name: 
+      - pax-utils
+      - qemu
+      - qemu-kvm
+      - libvirt-clients
+      - libvirt-daemon-system
+      - virtinst
+      - bridge-utils
+    state: present
+  become: true
+  tags:
+    - virtualization_packages
+
+- name: Enable and start libvirtd service
+  ansible.builtin.systemd:
+    name: libvirtd
+    enabled: yes
+    state: started
+  become: true
+  tags:
+    - libvirtd_service
```
![스크린샷, 2023-11-07 13-07-10](https://github.com/IntelLabs/kAFL/assets/76202024/986310d4-0846-41d4-affa-989762a4d0de)




### libvirt box name changed
When Windows was completely boxed using the `make build` command, the name of the output changed from packer_windows_libvirt.box to **packer_windows_libvirt_amd64.box** as shown in the picture below.

i think this caused by libvirt package ( i guess so )
![스크린샷, 2023-11-07 14-18-54](https://github.com/IntelLabs/kAFL/assets/76202024/f323c088-b4e4-4211-93c3-1f7829edc96b)


