### PR TITLE
deploy: remove Vagrant pinning

### DIFF
--- a/deploy/intellabs/kafl/roles/examples/tasks/template_windows.yml
+++ b/deploy/intellabs/kafl/roles/examples/tasks/template_windows.yml
@@ -38,8 +38,7 @@
   ansible.builtin.apt:
     name:
       - packer
-      # vagrant-host-shell plugin doesn't support 2.3.7-1 or newer
-      - vagrant=2.3.6-1
+      - vagrant
       # dependency for vagrant plugins
       - ruby-dev
       # dependency for vagrant-libvirt

--- a/docs/source/tutorials/windows/windows_template.md
+++ b/docs/source/tutorials/windows/windows_template.md
@@ -42,7 +42,7 @@ To verify your installation:
 $ packer version
 Packer v1.9.1 # or above
 $ vagrant version
-Installed Version: 2.3.6 # pinned 2.3.6
+Installed Version: 2.3.6
 Latest Version: 2.3.7
 ...
 $ vagrant plugin list


### PR DESCRIPTION
Following https://github.com/IntelLabs/kafl.targets/pull/36

We don't need to pin Vagrant to 2.3.6 anymore