### PR TITLE
example: fix libvirt tooling dependency

### DIFF
--- a/deploy/intellabs/kafl/roles/examples/tasks/template_windows.yml
+++ b/deploy/intellabs/kafl/roles/examples/tasks/template_windows.yml
@@ -43,6 +43,7 @@
       - ruby-dev
       # dependency for vagrant-libvirt
       - libvirt-dev
+      - libvirt-daemon-system
     update_cache: true
   become: true
 


### PR DESCRIPTION
Hi,

This PR addresses the dependency on Libvirt required by Vagrant. The `libvirt-daemon-system` package installs the `libvirtd.service` along with other necessary sockets (e.g., network). I hope this is helpful.

Looking forward to your feedback and wishing you a productive day!