### PR TITLE
docs: add missing libffi-dev setup dependency

### DIFF
--- a/docs/source/tutorials/installation.md
+++ b/docs/source/tutorials/installation.md
@@ -43,7 +43,7 @@ The requirements for either of these setups:
 
 The following command will install the required software on Ubuntu
 ```shell
-sudo apt-get install -y python3-dev python3-venv git build-essential
+sudo apt-get install -y python3-dev python3-venv git build-essential libffi-dev
 ```
 
 :::{note}


### PR DESCRIPTION
~~~
      copying cffi/_cffi_errors.h -> build/lib.linux-x86_64-cpython-312/cffi
      running build_ext
      building '_cffi_backend' extension
      creating build/temp.linux-x86_64-cpython-312/c
      x86_64-linux-gnu-gcc -fno-strict-overflow -Wsign-compare -DNDEBUG -g -O2 -Wall -fPIC -DUSE__THREAD -DHAVE_SYNC_SYNCHRONIZE -I/usr/include/ffi -I/usr/include/libffi -I/home/mtarral/kAFL/deploy/venv/include -I/usr/include/python3.12 -c c/_cffi_backend.c -o build/temp.linux-x86_64-cpython-312/c/_cffi_backend.o
      c/_cffi_backend.c:15:10: fatal error: ffi.h: No such file or directory
         15 | #include <ffi.h>
            |          ^~~~~~~
      compilation terminated.
      error: command '/usr/bin/x86_64-linux-gnu-gcc' failed with exit code 1
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for cffi
  Building wheel for MarkupSafe (pyproject.toml) ... done
  Created wheel for MarkupSafe: filename=MarkupSafe-2.1.1-cp312-cp312-linux_x86_64.whl size=27936 sha256=9af43df2dc022416b54328936262a8f76e5f0b5abff8f5de88e7db02c34e579d
~~~